### PR TITLE
Reafactor XML parsing

### DIFF
--- a/relaxng-exemplifier/Cargo.toml
+++ b/relaxng-exemplifier/Cargo.toml
@@ -13,4 +13,3 @@ bigdecimal = "0.4"
 [dev-dependencies]
 tempfile = "3"
 relaxng-validator = { path = "../relaxng-validator" }
-xmlparser = "0.13"

--- a/relaxng-exemplifier/tests/validate.rs
+++ b/relaxng-exemplifier/tests/validate.rs
@@ -3,7 +3,6 @@ use relaxng_model::model::DefineRule;
 use relaxng_model::{Compiler, FsFiles, Syntax};
 use relaxng_validator::Validator;
 use std::cell::RefCell;
-use std::collections::HashSet;
 use std::rc::Rc;
 
 fn compile(rnc: &str) -> Rc<RefCell<Option<DefineRule>>> {
@@ -15,14 +14,9 @@ fn compile(rnc: &str) -> Rc<RefCell<Option<DefineRule>>> {
 }
 
 fn assert_valid(model: Rc<RefCell<Option<DefineRule>>>, doc: &str) {
-    let reader = xmlparser::Tokenizer::from(doc);
-    let mut v = Validator::new(model, reader).expect("compile validator");
-    loop {
-        match v.validate_next() {
-            Some(Ok(())) => {}
-            Some(Err(e)) => panic!("validation error: {e:?}\ndoc:\n{doc}"),
-            None => break,
-        }
+    let mut v = Validator::new(model).expect("compile validator");
+    if let Err(e) = v.validate(doc.as_bytes()) {
+        panic!("validation error: {e:?}\ndoc:\n{doc}");
     }
 }
 
@@ -157,45 +151,10 @@ fn coverage_nested_choice() {
     }
 }
 
-/// Parse `doc` and return every `(local_name, prefix)` pair that appears more
-/// than once on the same element.
-fn duplicate_attrs(doc: &str) -> Vec<(String, String)> {
-    let mut duplicates = Vec::new();
-    let mut stack: Vec<HashSet<(String, String)>> = Vec::new();
-    for token in xmlparser::Tokenizer::from(doc) {
-        match token.unwrap() {
-            xmlparser::Token::ElementStart { .. } => {
-                stack.push(HashSet::new());
-            }
-            xmlparser::Token::Attribute { prefix, local, .. } => {
-                let key = (local.as_str().to_string(), prefix.as_str().to_string());
-                if let Some(seen) = stack.last_mut() {
-                    if !seen.insert(key.clone()) {
-                        duplicates.push(key);
-                    }
-                }
-            }
-            xmlparser::Token::ElementEnd { .. } => {
-                stack.pop();
-            }
-            _ => {}
-        }
-    }
-    duplicates
-}
-
-fn assert_no_duplicate_attrs(doc: &str) {
-    let dups = duplicate_attrs(doc);
-    assert!(
-        dups.is_empty(),
-        "duplicate attributes {:?} in:\n{}",
-        dups,
-        doc
-    );
-}
-
-// A schema where ZeroOrMore wraps a named attribute - the most direct way to
-// trigger duplicates before the fix.
+// A schema where ZeroOrMore wraps a named attribute — the most direct way to
+// trigger duplicates before the fix. The validator rejects duplicate attributes
+// at `attribute_end`, so `assert_valid` covers what the old custom xmlparser
+// walk used to.
 const REPEATED_ATTR: &str =
     "start = element root { attribute tag { text }*, element body { empty } }";
 
@@ -205,7 +164,6 @@ fn no_duplicate_attrs_repeated_attr() {
     let generator = Generator::new(model.clone(), 20);
     for seed in 0..64 {
         let doc = generator.generate_with_seed(seed);
-        assert_no_duplicate_attrs(&doc);
         assert_valid(model.clone(), &doc);
     }
 }
@@ -215,7 +173,6 @@ fn no_duplicate_attrs_coverage_repeated() {
     let model = compile(REPEATED_ATTR);
     let generator = Generator::new(model.clone(), 20);
     for doc in generator.coverage_tour() {
-        assert_no_duplicate_attrs(&doc);
         assert_valid(model.clone(), &doc);
     }
 }

--- a/relaxng-tool/src/main.rs
+++ b/relaxng-tool/src/main.rs
@@ -3,7 +3,7 @@ use relaxng_model::{Compiler, Syntax};
 use relaxng_validator::{CoverageReport, Validator};
 
 use std::fs::File;
-use std::io::Read;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
@@ -99,21 +99,24 @@ fn compile_schema(syntax: Syntax, schema: &Path) -> relaxng_model::CompileResult
     }
 }
 
-fn run_validation<'a>(v: &mut Validator<'a>, xml: &Path, doc: String) {
-    loop {
-        match v.validate_next() {
-            Some(Ok(())) => {}
-            Some(Err(err)) => {
-                let (map, d) = v.diagnostic(xml.to_string_lossy().to_string(), doc, &err);
-                let mut emitter = codemap_diagnostic::Emitter::stderr(
-                    codemap_diagnostic::ColorConfig::Auto,
-                    Some(&map),
-                );
-                emitter.emit(&d[..]);
-                exit(2);
-            }
-            None => break,
+fn run_validation(v: &mut Validator, xml: &Path) {
+    let f = File::open(xml).unwrap_or_else(|e| {
+        eprintln!("Error opening {xml:?}: {e}");
+        exit(1);
+    });
+    if let Err(err) = v.validate_reader(BufReader::new(f)) {
+        // Re-read the file for diagnostic context
+        if let Ok(source) = std::fs::read(xml) {
+            let (map, d) = v.diagnostic(xml.to_string_lossy().to_string(), &source, &err);
+            let mut emitter = codemap_diagnostic::Emitter::stderr(
+                codemap_diagnostic::ColorConfig::Auto,
+                Some(&map),
+            );
+            emitter.emit(&d[..]);
+        } else {
+            eprintln!("Validation error in {xml:?}: {err}");
         }
+        exit(2);
     }
 }
 
@@ -121,14 +124,9 @@ fn validate(syntax: Syntax, schema: PathBuf, xmls: Vec<PathBuf>) {
     let result = compile_schema(syntax, &schema);
     let model = result.start;
     for xml in &xmls {
-        let mut f = File::open(xml).expect("open example xml");
-        let mut doc = String::new();
-        f.read_to_string(&mut doc).expect("read xml");
-        let src = doc.clone();
-        let reader = xmlparser::Tokenizer::from(&src[..]);
-        let mut v = Validator::new(model.clone(), reader).expect("compile validator");
+        let mut v = Validator::new(model.clone()).expect("compile validator");
         eprintln!("Validating {xml:?}");
-        run_validation(&mut v, xml, doc);
+        run_validation(&mut v, xml);
     }
 }
 
@@ -144,14 +142,9 @@ fn coverage(syntax: Syntax, schema: PathBuf, xmls: Vec<PathBuf>, format: &str) {
     let model = result.start;
     let mut merged_report: Option<CoverageReport> = None;
     for xml in &xmls {
-        let mut f = File::open(xml).expect("open example xml");
-        let mut doc = String::new();
-        f.read_to_string(&mut doc).expect("read xml");
-        let src = doc.clone();
-        let reader = xmlparser::Tokenizer::from(&src[..]);
-        let mut v = Validator::new_with_coverage(model.clone(), reader).expect("compile validator");
+        let mut v = Validator::new_with_coverage(model.clone()).expect("compile validator");
         eprintln!("Validating {xml:?}");
-        run_validation(&mut v, xml, doc);
+        run_validation(&mut v, xml);
         if let Some(report) = v.coverage_report() {
             match merged_report {
                 Some(ref mut merged) => merged.merge(&report),

--- a/relaxng-validator/Cargo.toml
+++ b/relaxng-validator/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 [dependencies]
 relaxng-model = { path = "../relaxng-model" }
 relaxng-syntax = { path = "../relaxng-syntax" }
-xmlparser = "0.13.3"
+xml-syntax-reader = { version = "0.2", features = ["dtd"] }
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
 fnv = "1.0.7"

--- a/relaxng-validator/benches/bench.rs
+++ b/relaxng-validator/benches/bench.rs
@@ -5,7 +5,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
-use xmlparser::Tokenizer;
 
 /// schema exercising most features:
 /// - Namespaces (default + prefixed)
@@ -281,15 +280,9 @@ fn compile_schema() -> Rc<RefCell<Option<relaxng_model::model::DefineRule>>> {
 }
 
 fn validate(schema: Rc<RefCell<Option<relaxng_model::model::DefineRule>>>, doc: &str) {
-    let tokenizer = Tokenizer::from(doc);
-    let mut v = Validator::new(schema, tokenizer).unwrap();
-    loop {
-        match v.validate_next() {
-            None => break,
-            Some(Ok(())) => {}
-            Some(Err(e)) => panic!("Validation error: {e:?}"),
-        }
-    }
+    let mut v = Validator::new(schema).unwrap();
+    v.validate(doc.as_bytes())
+        .unwrap_or_else(|e| panic!("Validation error: {e:?}"));
 }
 
 fn bench_compile(c: &mut Criterion) {

--- a/relaxng-validator/src/derivative.rs
+++ b/relaxng-validator/src/derivative.rs
@@ -193,16 +193,15 @@ impl Schema {
     }
 
     pub(crate) fn start_tag_open_deriv(&mut self, pid: PatId, name: QualifiedName) -> PatId {
-        let local_key: Box<str> = name.local_name.into();
-        let ns_key: Option<Box<str>> = name.namespace_uri.map(|s| s.into());
+        let local_key: Box<[u8]> = name.local_name.into();
+        let ns_key = self.ns_interner.intern_opt(name.namespace_uri);
 
         // Cache check (borrow released before any mutation)
         {
             let inner = self.inner.borrow();
-            if let Some(&cached) =
-                inner
-                    .start_tag_open_cache
-                    .get(&(pid, local_key.clone(), ns_key.clone()))
+            if let Some(&cached) = inner
+                .start_tag_open_cache
+                .get(&(pid, local_key.clone(), ns_key))
             {
                 return cached;
             }
@@ -240,7 +239,7 @@ impl Schema {
                 }
             }
             Pat::Element(ref nc, inner_pat) => {
-                if contains(nc, name) {
+                if contains(nc, &name) {
                     self.mark_covered(pid);
                     let empty = self.empty();
                     self.after(inner_pat, empty)
@@ -271,16 +270,12 @@ impl Schema {
     }
 
     pub(crate) fn start_att_deriv(&mut self, pid: PatId, name: QualifiedName) -> PatId {
-        let local_key: Box<str> = name.local_name.into();
-        let ns_key: Option<Box<str>> = name.namespace_uri.map(|s| s.into());
+        let local_key: Box<[u8]> = name.local_name.into();
+        let ns_key = self.ns_interner.intern_opt(name.namespace_uri);
 
         {
             let inner = self.inner.borrow();
-            if let Some(&cached) =
-                inner
-                    .start_att_cache
-                    .get(&(pid, local_key.clone(), ns_key.clone()))
-            {
+            if let Some(&cached) = inner.start_att_cache.get(&(pid, local_key.clone(), ns_key)) {
                 return cached;
             }
         }
@@ -315,7 +310,7 @@ impl Schema {
                 self.choice(x, y)
             }
             Pat::Attribute(ref nc, val_pat) => {
-                if contains(nc, name) {
+                if contains(nc, &name) {
                     self.mark_covered(pid);
                     let empty = self.empty();
                     self.after(val_pat, empty)

--- a/relaxng-validator/src/lib.rs
+++ b/relaxng-validator/src/lib.rs
@@ -4,50 +4,203 @@ mod nameclass;
 mod schema;
 
 use relaxng_model::model;
-use relaxng_model::model::NameClass;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 use std::rc::Rc;
-use xmlparser::{ElementEnd, EntityDefinition, StrSpan, Token, Tokenizer};
+use xml_syntax_reader::{EntityKind, ErrorKind, ParseError, QName, Span, Visitor};
 
 pub use coverage::{CoverageReport, TrackablePattern};
-use nameclass::*;
+use nameclass::{is_ncname, *};
 use schema::*;
 
 #[derive(Debug)]
-pub enum ValidatorError<'a> {
-    Xml(xmlparser::Error),
-    NotAllowed(Token<'a>),
+pub enum ValidatorError {
+    /// XML well-formedness error from the parser.
+    Xml(xml_syntax_reader::Error),
+    /// The XML construct at the given span is not allowed by the schema.
+    NotAllowed {
+        span: Range<u64>,
+        kind: &'static str,
+    },
     UndefinedNamespacePrefix {
-        prefix: StrSpan<'a>,
+        prefix: String,
+        span: Range<u64>,
     },
     UndefinedEntity {
-        name: &'a str,
-        span: std::ops::Range<usize>,
+        name: String,
+        span: Range<u64>,
     },
     InvalidOrUnclosedEntity {
-        span: std::ops::Range<usize>,
+        span: Range<u64>,
+    },
+    /// An element or attribute name is not a valid XML Name.
+    InvalidName {
+        span: Range<u64>,
+        kind: &'static str,
+    },
+    /// Duplicate attribute on the same element.
+    DuplicateAttribute {
+        span: Range<u64>,
+    },
+    /// Too many attributes on a single element.
+    TooManyAttributes {
+        span: Range<u64>,
+    },
+    /// Bytes that should be UTF-8 (e.g. a namespace prefix) were not valid UTF-8.
+    InvalidUtf8 {
+        span: Range<u64>,
+        kind: &'static str,
     },
     TextBufferOverflow,
+    Io(std::io::Error),
     Schema(SchemaError),
 }
 
-pub struct Validator<'a> {
-    schema: Schema,
-    tokenizer: Tokenizer<'a>,
-    current_step: PatId,
-    last_was_start_element: bool,
-    stack: ElementStack<'a>,
-    entity_definitions: HashMap<String, String>,
-    text_buffer: String,
-    max_text_buffer: usize,
+impl std::fmt::Display for ValidatorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatorError::Xml(e) => write!(f, "XML error: {e:?}"),
+            ValidatorError::NotAllowed { kind, .. } => write!(f, "{kind} not expected here"),
+            ValidatorError::UndefinedNamespacePrefix { prefix, .. } => {
+                write!(f, "The prefix \"{prefix}\" is not defined")
+            }
+            ValidatorError::UndefinedEntity { name, .. } => {
+                write!(f, "The entity &{name}; is not defined")
+            }
+            ValidatorError::InvalidOrUnclosedEntity { .. } => {
+                write!(f, "Invalid or unclosed entity reference")
+            }
+            ValidatorError::InvalidName { kind, .. } => {
+                write!(f, "{kind} name is not a valid XML Name")
+            }
+            ValidatorError::DuplicateAttribute { .. } => {
+                write!(f, "duplicate attribute")
+            }
+            ValidatorError::TooManyAttributes { .. } => {
+                write!(f, "too many attributes on element (limit: 256)")
+            }
+            ValidatorError::InvalidUtf8 { kind, .. } => {
+                write!(f, "{kind} contains invalid UTF-8")
+            }
+            ValidatorError::TextBufferOverflow => {
+                write!(f, "Text content exceeds maximum buffer size")
+            }
+            ValidatorError::Io(e) => write!(f, "I/O error: {e}"),
+            ValidatorError::Schema(SchemaError::TooManyPatterns) => {
+                write!(f, "Schema exceeds maximum number of patterns (65535)")
+            }
+        }
+    }
 }
 
-impl<'a> Validator<'a> {
-    pub fn new(
-        model: Rc<RefCell<Option<model::DefineRule>>>,
-        tokenizer: Tokenizer<'a>,
-    ) -> Result<Validator<'a>, ValidatorError<'a>> {
+/// Arena for element/attribute names and attribute values within a single
+/// opening tag. All data is appended to one `Vec<u8>` and referenced by
+/// `(start, len)` ranges. Reset after `close_element_start` consumes everything.
+struct TagArena {
+    buf: Vec<u8>,
+}
+
+impl Default for TagArena {
+    fn default() -> Self {
+        TagArena {
+            buf: Vec::with_capacity(512),
+        }
+    }
+}
+
+/// Range into the `TagArena` for a short name (max 65535 bytes).
+type NameRange = (u32, u16);
+/// Range into the `TagArena` for an attribute value (may be longer).
+type ValueRange = (u32, u32);
+
+impl TagArena {
+    /// Append bytes and return a name-sized range.
+    fn push_name(&mut self, name: &[u8]) -> NameRange {
+        let start = self.buf.len() as u32;
+        self.buf.extend_from_slice(name);
+        (start, name.len() as u16)
+    }
+
+    /// Mark the start of an attribute value being accumulated.
+    fn begin_value(&self) -> u32 {
+        self.buf.len() as u32
+    }
+
+    /// Append bytes to the current attribute value.
+    fn push_value_bytes(&mut self, data: &[u8]) {
+        self.buf.extend_from_slice(data);
+    }
+
+    /// Append a single char (for entity/char ref expansion).
+    fn push_value_char(&mut self, c: char) {
+        let mut tmp = [0u8; 4];
+        let s = c.encode_utf8(&mut tmp);
+        self.buf.extend_from_slice(s.as_bytes());
+    }
+
+    /// Append a str to the current attribute value.
+    fn push_value_str(&mut self, s: &str) {
+        self.buf.extend_from_slice(s.as_bytes());
+    }
+
+    /// Finish an attribute value and return its range.
+    fn finish_value(&self, start: u32) -> ValueRange {
+        (start, self.buf.len() as u32)
+    }
+
+    /// Get the raw bytes for a name range.
+    fn get_name(&self, range: NameRange) -> &[u8] {
+        let start = range.0 as usize;
+        let end = start + range.1 as usize;
+        &self.buf[start..end]
+    }
+
+    /// Get a `&str` for a value range. Infallible by construction: every
+    /// `push_value_*` call site contributes valid UTF-8 (validated at the
+    /// `attribute_value` / `attribute_entity_ref` visitor boundaries, or
+    /// produced by `c.encode_utf8` / a `&str` source). Concatenation of
+    /// valid UTF-8 is valid UTF-8.
+    fn get_value(&self, range: ValueRange) -> &str {
+        let start = range.0 as usize;
+        let end = range.1 as usize;
+        let bytes = &self.buf[start..end];
+        debug_assert!(
+            std::str::from_utf8(bytes).is_ok(),
+            "TagArena value invariant violated"
+        );
+        std::str::from_utf8(bytes).expect("TagArena values are valid UTF-8 by construction")
+    }
+
+    fn clear(&mut self) {
+        self.buf.clear();
+    }
+}
+
+pub struct Validator {
+    schema: Schema,
+    current_step: PatId,
+    last_was_start_element: bool,
+    stack: ElementStack,
+    entity_definitions: HashMap<String, String>,
+    /// Text content buffered for deferred `text_deriv`. UTF-8 is enforced at
+    /// the visitor boundary (`append_text_bytes`); pre-validated callers go
+    /// through `append_validated_text`.
+    text_buffer: String,
+    /// Source span covering the buffered text run, used for diagnostics on
+    /// `flush_text` failure. `None` when the buffer is empty.
+    text_buffer_span: Option<Span>,
+    max_text_buffer: usize,
+    arena: TagArena,
+    // Attribute accumulation state — names and value stored in the arena
+    current_attr_prefix: Option<NameRange>,
+    current_attr_local: NameRange,
+    current_attr_name_span: Span,
+    current_attr_value_start: u32,
+}
+
+impl Validator {
+    pub fn new(model: Rc<RefCell<Option<model::DefineRule>>>) -> Result<Validator, ValidatorError> {
         let (schema, start) = build_schema(&model).map_err(ValidatorError::Schema)?;
         let mut entity_definitions = HashMap::default();
         entity_definitions.insert("lt".to_string(), "<".to_string());
@@ -57,22 +210,26 @@ impl<'a> Validator<'a> {
         entity_definitions.insert("quot".to_string(), "\"".to_string());
         Ok(Validator {
             schema,
-            tokenizer,
             current_step: start,
             last_was_start_element: false,
             stack: ElementStack::default(),
             entity_definitions,
             text_buffer: String::new(),
+            text_buffer_span: None,
             max_text_buffer: 1024 * 1024,
+            arena: TagArena::default(),
+            current_attr_prefix: None,
+            current_attr_local: (0, 0),
+            current_attr_name_span: Span::new(0, 0),
+            current_attr_value_start: 0,
         })
     }
 
     /// Create a validator with coverage tracking enabled.
     pub fn new_with_coverage(
         model: Rc<RefCell<Option<model::DefineRule>>>,
-        tokenizer: Tokenizer<'a>,
-    ) -> Result<Validator<'a>, ValidatorError<'a>> {
-        let mut v = Self::new(model, tokenizer)?;
+    ) -> Result<Validator, ValidatorError> {
+        let mut v = Self::new(model)?;
         let compile_time_count = v.schema.inner.borrow().patterns.len() as u16;
         let word_count = (compile_time_count as usize).div_ceil(64);
         v.schema.compile_time_count = compile_time_count;
@@ -80,23 +237,61 @@ impl<'a> Validator<'a> {
         Ok(v)
     }
 
+    /// Validate an XML document already in memory.
+    pub fn validate(&mut self, source: &[u8]) -> Result<(), ValidatorError> {
+        let mut reader = xml_syntax_reader::Reader::new();
+        reader.parse_slice(source, self).map_err(map_parse_error)?;
+        self.finish_validation()
+    }
+
+    /// Validate XML from a streaming reader, without loading the entire document into memory.
+    pub fn validate_reader<R: std::io::Read>(
+        &mut self,
+        mut reader: R,
+    ) -> Result<(), ValidatorError> {
+        let mut xml_reader = xml_syntax_reader::Reader::new();
+        let mut buf = vec![0u8; 65536];
+        let mut valid: usize = 0;
+        let mut stream_offset: u64 = 0;
+
+        loop {
+            let n = reader.read(&mut buf[valid..]).map_err(ValidatorError::Io)?;
+            valid += n;
+            let is_final = n == 0;
+
+            let consumed = xml_reader
+                .parse(&buf[..valid], stream_offset, is_final, self)
+                .map_err(map_parse_error)?;
+
+            let consumed = consumed as usize;
+            let leftover = valid - consumed;
+            if leftover > 0 {
+                buf.copy_within(consumed..valid, 0);
+            }
+            valid = leftover;
+            stream_offset += consumed as u64;
+
+            if is_final && consumed == 0 {
+                break;
+            }
+        }
+
+        self.finish_validation()
+    }
+
+    fn finish_validation(&mut self) -> Result<(), ValidatorError> {
+        self.flush_text()
+    }
+
     /// Extract the coverage report. Returns `None` if coverage tracking was not enabled.
     pub fn coverage_report(&self) -> Option<CoverageReport> {
         self.schema.build_coverage_report()
     }
 
-    pub fn validate_next(&mut self) -> Option<Result<(), ValidatorError<'a>>> {
-        match self.tokenizer.next() {
-            Some(Ok(evt)) => Some(self.validate(evt)),
-            Some(Err(err)) => Some(Err(ValidatorError::Xml(err))),
-            None => None,
-        }
-    }
-
     /// Ensure ns_context is up to date if it has been invalidated.
     fn ensure_ns_context(&mut self) {
         if self.schema.ns_context_dirty {
-            self.schema.ns_context = if self.stack.elements.is_empty() {
+            self.schema.ns_context = if self.stack.scopes.is_empty() {
                 None
             } else {
                 Some(self.stack.capture_ns_context())
@@ -105,297 +300,243 @@ impl<'a> Validator<'a> {
         }
     }
 
-    /// Flush any buffered text by applying text_deriv.
-    /// Returns true if the result was NotAllowed.
-    fn flush_text(&mut self) -> bool {
-        if !self.text_buffer.is_empty() {
-            let next_id = self.schema.text_deriv(self.current_step, &self.text_buffer);
-            self.text_buffer.clear();
-            self.current_step = next_id;
-            matches!(self.schema.patt(next_id), Pat::NotAllowed)
-        } else {
-            false
+    /// Flush any buffered text by applying `text_deriv`. On `NotAllowed`,
+    /// returns a `text` error tagged with the buffered run's span.
+    fn flush_text(&mut self) -> Result<(), ValidatorError> {
+        if self.text_buffer.is_empty() {
+            return Ok(());
         }
+        let next_id = self.schema.text_deriv(self.current_step, &self.text_buffer);
+        let buf_span = self.text_buffer_span.take();
+        self.text_buffer.clear();
+        self.current_step = next_id;
+        if matches!(self.schema.patt(next_id), Pat::NotAllowed) {
+            let span = buf_span.map(|s| s.start..s.end).unwrap_or(0..0);
+            return Err(ValidatorError::NotAllowed { span, kind: "text" });
+        }
+        Ok(())
     }
 
-    #[allow(unused)]
-    fn assert_health(&self) {
-        let mut seen = vec![];
-        self.schema.check_choices(self.current_step, &mut seen);
+    /// Append a text fragment whose bytes came directly from the parser.
+    /// Validates UTF-8 (per fragment, so the diagnostic span is precise) and
+    /// then either skips storage on the fixed-point branch or buffers for
+    /// deferred `text_deriv`.
+    fn append_text_bytes(
+        &mut self,
+        bytes: &[u8],
+        span: Span,
+        kind: &'static str,
+    ) -> Result<(), ValidatorError> {
+        // Any text content (even fixed-point) means this element is not empty,
+        // so clear the flag that would trigger an empty-text derivative on close.
+        self.last_was_start_element = false;
+        // Validate UTF-8 unconditionally — the validator rejects malformed
+        // documents even when the schema's pattern accepts arbitrary text
+        // (e.g. `text` / mixed content). The fixed-point fast path below skips
+        // the buffer copy and the `text_deriv` walk, not the UTF-8 check.
+        let s = std::str::from_utf8(bytes).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind,
+        })?;
+        if self.schema.mixed_text_deriv(self.current_step) == self.current_step {
+            return Ok(());
+        }
+        self.append_str(s, span)
     }
 
-    fn validate(&mut self, evt: Token<'a>) -> Result<(), ValidatorError<'a>> {
+    /// Append text whose bytes are already known to be valid UTF-8 (an
+    /// expanded entity-reference value or an encoded character reference).
+    fn append_validated_text(&mut self, s: &str, span: Span) -> Result<(), ValidatorError> {
+        self.last_was_start_element = false;
+        if self.schema.mixed_text_deriv(self.current_step) == self.current_step {
+            return Ok(());
+        }
+        self.append_str(s, span)
+    }
+
+    fn append_str(&mut self, s: &str, span: Span) -> Result<(), ValidatorError> {
+        // Buffer text for deferred processing — text fragments split by
+        // PIs/comments must be concatenated before validation (spec 6.2.7).
+        self.text_buffer.push_str(s);
+        if self.text_buffer.len() > self.max_text_buffer {
+            return Err(ValidatorError::TextBufferOverflow);
+        }
+        match self.text_buffer_span {
+            None => self.text_buffer_span = Some(span),
+            Some(ref mut existing) if span.end > existing.end => existing.end = span.end,
+            Some(_) => {}
+        }
+        Ok(())
+    }
+
+    fn close_element_start(&mut self, span: Span) -> Result<(), ValidatorError> {
         self.ensure_ns_context();
-        let new = match evt {
-            Token::EmptyDtd { .. }
-            | Token::Comment { .. }
-            | Token::ProcessingInstruction { .. } => {
-                // does not change current_step state
-                return Ok(());
-            }
-            Token::ElementStart {
-                prefix,
-                local,
-                span,
-            } => {
-                if self.flush_text() {
-                    return Err(ValidatorError::NotAllowed(evt));
-                }
-                self.stack.push(prefix, local, span);
-                // does not change current_step state
-                return Ok(());
-            }
-            /*
-                let next_pat = Self::start_tag_open_deriv(pat, &mut self.schema, namespace, &name);
-                // TODO: refactor early-returns
-                let next_pat = match self.schema.patt(next_pat) {
-                    Pat::NotAllowed => return Err(ValidatorError::NotAllowed(evt)),
-                    p => Self::attrs_deriv(next_pat, &mut self.schema, attributes)
-                };
-                let next_pat = match self.schema.patt(next_pat) {
-                    Pat::NotAllowed => return Err(ValidatorError::NotAllowed(evt)),
-                    p => Self::start_tag_close_deriv(next_pat, &mut self.schema)
-                };
-                match self.schema.patt(next_pat) {
-                    Pat::NotAllowed => return Err(ValidatorError::NotAllowed(evt)),
-                    p => next_pat //Self::children_deriv(next_pat, &mut self.schema)
-                }
-            */
-            Token::Attribute {
-                prefix,
-                local,
-                value,
-                span,
-            } => {
-                if prefix.as_str() == "xmlns"
-                    || (prefix.as_str() == "" && local.as_str() == "xmlns")
-                {
-                    self.schema.ns_context_dirty = true;
-                }
-                self.stack.add_attr(prefix, local, value, span);
-                // does not change current_step state
-                return Ok(());
-            }
-            Token::ElementEnd { end, span: _ } => {
-                if self.flush_text() {
-                    return Err(ValidatorError::NotAllowed(evt));
-                }
-                match end {
-                    ElementEnd::Open => Self::close_element_start(
-                        &self.stack,
-                        &mut self.schema,
-                        evt,
-                        self.current_step,
-                    )?,
-                    ElementEnd::Close(_, _) => {
-                        let next_pid = if self.last_was_start_element {
-                            // The last event was XmlEvent::StartElement with no child elements or child
-                            // text nodes.
-                            //
-                            // Per https://relaxng.org/jclark/derivative.html ,
-                            //     "The case where the list of children is empty is
-                            //      treated as if there were a text node whose value
-                            //      were the empty string."
-                            //
-                            // This fake text node is required for a pattern like 'element foo { token }'
-                            // to match the input '<foo/>' or '<foo></foo>'
-                            self.schema.text_deriv(self.current_step, "")
-                        } else {
-                            self.current_step
-                        };
-                        let result = self.schema.end_tag_deriv(next_pid);
-                        if self.stack.pop_has_namespaces() {
-                            self.schema.ns_context_dirty = true;
-                        }
-                        result
-                    }
-                    ElementEnd::Empty => {
-                        let next_id = Self::close_element_start(
-                            &self.stack,
-                            &mut self.schema,
-                            evt,
-                            self.current_step,
-                        )?;
-                        // The last event was XmlEvent::StartElement with no child elements or child
-                        // text nodes.
-                        //
-                        // Per https://relaxng.org/jclark/derivative.html ,
-                        //     "The case where the list of children is empty is
-                        //      treated as if there were a text node whose value
-                        //      were the empty string."
-                        //
-                        // This fake text node is required for a pattern like 'element foo { token }'
-                        // to match the input '<foo/>' or '<foo></foo>'
-                        let p = self.schema.text_deriv(next_id, "");
-                        let result = self.schema.end_tag_deriv(p);
-                        if self.stack.pop_has_namespaces() {
-                            self.schema.ns_context_dirty = true;
-                        }
-                        result
-                    }
-                }
-            }
-            Token::Cdata { text, span: _ } => {
-                if self.flush_text() {
-                    return Err(ValidatorError::NotAllowed(evt));
-                }
-                let mixed = self.schema.mixed_text_deriv(self.current_step);
-                if mixed == self.current_step {
-                    self.current_step
-                } else {
-                    self.schema.text_deriv(self.current_step, &text)
-                }
-            }
-            Token::Text { text } => {
-                let mut buffer = String::new();
-                for val in parse_entities(text.start(), text.as_str()) {
-                    match val {
-                        Ok(val) => {
-                            let txt = match val {
-                                Txt::Text(_pos, val) => val,
-                                Txt::Entity(pos, name) => {
-                                    if let Some(txt) = self.entity_definitions.get(name) {
-                                        txt
-                                    } else {
-                                        return Err(ValidatorError::UndefinedEntity {
-                                            name,
-                                            span: pos..pos + name.len(),
-                                        });
-                                    }
-                                }
-                                Txt::Char(_pos, val) => {
-                                    buffer.push(val);
-                                    continue;
-                                }
-                            };
-                            // we only reach this point for Txt::Text and Txt::Entity cases,
-                            if txt.len() == text.len() {
-                                // no need to copy data into the buffer, just process the whole input in one go
-                                break;
-                            } else {
-                                // the input contains entities, so we decode these and append to buffer
-                                buffer.push_str(txt);
-                            }
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                }
-                let data = if buffer.is_empty() {
-                    text.as_str()
-                } else {
-                    &buffer[..]
-                };
-                // Fast path: if mixed_text_deriv returns the same PatId, the pattern is a
-                // text fixed-point (e.g. After(Text, cont)) and text_deriv is a no-op.
-                let mixed = self.schema.mixed_text_deriv(self.current_step);
-                if mixed == self.current_step {
-                    self.current_step
-                } else {
-                    // Buffer text for deferred processing — text fragments split by
-                    // PIs/comments must be concatenated before validation (spec 6.2.7).
-                    self.text_buffer.push_str(data);
-                    if self.text_buffer.len() > self.max_text_buffer {
-                        return Err(ValidatorError::TextBufferOverflow);
-                    }
-                    self.last_was_start_element = false;
-                    return Ok(());
-                }
-            }
-            Token::EntityDeclaration {
-                name,
-                definition,
-                span: _,
-            } => {
-                match definition {
-                    EntityDefinition::EntityValue(val) => {
-                        self.entity_definitions
-                            .insert(name.to_string(), val.to_string());
-                        // does not change current_step state
-                        return Ok(());
-                    }
-                    EntityDefinition::ExternalId(_) => {
-                        // no support for resolving external ids
-                        // does not change current_step state
-                        return Err(ValidatorError::NotAllowed(evt));
-                    }
-                }
-            }
-            Token::Declaration { .. } | Token::DtdStart { .. } | Token::DtdEnd { .. } => {
-                // does not change current_step state
-                return Ok(());
-            }
+
+        // Resolve element name — prefix/local borrow from the name arena
+        let curr = self.stack.scopes.last().unwrap();
+        let elem_name_span = curr.name_span;
+        let elem_prefix_bytes = curr.prefix.map(|r| self.arena.get_name(r));
+        let elem_ns = self
+            .stack
+            .resolve_element_namespace(elem_prefix_bytes, elem_name_span)?;
+
+        let elem_qname = QualifiedName {
+            namespace_uri: elem_ns,
+            local_name: self.arena.get_name(self.stack.scopes.last().unwrap().local),
         };
-        if let Token::ElementEnd {
-            end: ElementEnd::Open,
-            ..
-        } = evt
-        {
-            self.last_was_start_element = true;
-        } else {
-            self.last_was_start_element = false;
+
+        let pat_id = self.current_step;
+        let next_pat = self.schema.start_tag_open_deriv(pat_id, elem_qname);
+        if matches!(self.schema.patt(next_pat), Pat::NotAllowed) {
+            let err = if !is_ncname(elem_qname.local_name) {
+                ValidatorError::InvalidName {
+                    span: elem_name_span.start..elem_name_span.end,
+                    kind: "element",
+                }
+            } else {
+                ValidatorError::NotAllowed {
+                    span: elem_name_span.start..elem_name_span.end,
+                    kind: "element-start",
+                }
+            };
+            self.arena.clear();
+            return Err(err);
         }
-        if let Pat::NotAllowed = self.schema.patt(new) {
-            Err(ValidatorError::NotAllowed(evt))
-        } else {
-            self.current_step = new;
-            Ok(())
+
+        // Process attributes — names borrow from the arena, attrs in flat buffer
+        let mut pat = next_pat;
+        let attr_start = self.stack.scopes.last().unwrap().attr_start as usize;
+        let num_attrs = self.stack.attrs.len() - attr_start;
+        for i in 0..num_attrs {
+            let attr = &self.stack.attrs[attr_start + i];
+            let attr_name_span = attr.name_span;
+            let attr_prefix_bytes = attr.prefix.map(|r| self.arena.get_name(r));
+            let attr_ns = self
+                .stack
+                .resolve_attribute_namespace(attr_prefix_bytes, attr_name_span)?;
+            let attr_qname = QualifiedName {
+                namespace_uri: attr_ns,
+                local_name: self.arena.get_name(self.stack.attrs[attr_start + i].local),
+            };
+            let mid = self.schema.start_att_deriv(pat, attr_qname);
+            let attr_value = self.arena.get_value(self.stack.attrs[attr_start + i].value);
+            pat = self.schema.att_value_deriv(mid, attr_value);
+            if matches!(self.schema.patt(pat), Pat::NotAllowed) {
+                let err = if !is_ncname(attr_qname.local_name) {
+                    ValidatorError::InvalidName {
+                        span: attr_name_span.start..attr_name_span.end,
+                        kind: "attribute",
+                    }
+                } else {
+                    ValidatorError::NotAllowed {
+                        span: attr_name_span.start..attr_name_span.end,
+                        kind: "attribute",
+                    }
+                };
+                self.arena.clear();
+                return Err(err);
+            }
         }
+
+        // Names are no longer needed — reset arena for the next opening tag
+        self.arena.clear();
+
+        if matches!(self.schema.patt(pat), Pat::NotAllowed) {
+            return Err(ValidatorError::NotAllowed {
+                span: span.start..span.end,
+                kind: "element-end",
+            });
+        }
+        let next_pat = self.schema.start_tag_close_deriv(pat);
+        if matches!(self.schema.patt(next_pat), Pat::NotAllowed) {
+            return Err(ValidatorError::NotAllowed {
+                span: span.start..span.end,
+                kind: "element-end",
+            });
+        }
+        self.current_step = next_pat;
+        self.last_was_start_element = true;
+        Ok(())
     }
 
-    fn close_element_start<'b: 'a>(
-        stack: &ElementStack<'b>,
-        schema: &mut Schema,
-        evt: Token<'b>,
-        pat_id: PatId,
-    ) -> Result<PatId, ValidatorError<'b>> {
-        let elem = stack.current_element()?;
-        let next_pat = schema.start_tag_open_deriv(pat_id, elem.name);
-        // TODO: refactor early-returns
-        let next_pat = match schema.patt(next_pat) {
-            Pat::NotAllowed => {
-                return Err(ValidatorError::NotAllowed(Token::ElementStart {
-                    prefix: elem.raw_prefix,
-                    local: elem.raw_local,
-                    span: elem.raw_local,
-                }));
-            }
-            _p => {
-                let attributes: Vec<_> = stack.current_attributes()?;
-                let mut pat = next_pat;
-                for att in attributes {
-                    let mid = schema.start_att_deriv(pat, att.name);
-                    pat = schema.att_value_deriv(mid, att.value);
-                    if let Pat::NotAllowed = schema.patt(pat) {
-                        return Err(ValidatorError::NotAllowed(Token::Attribute {
-                            prefix: att.raw_prefix,
-                            local: att.raw_local,
-                            value: att.raw_value,
-                            span: att.raw_span,
-                        }));
-                    }
-                }
-                pat
-            }
+    fn handle_end_tag(&mut self, span: Span) -> Result<(), ValidatorError> {
+        self.ensure_ns_context();
+        self.flush_text()?;
+        let next_pid = if self.last_was_start_element {
+            // The last event was XmlEvent::StartElement with no child elements or child
+            // text nodes.
+            //
+            // Per https://relaxng.org/jclark/derivative.html ,
+            //     "The case where the list of children is empty is
+            //      treated as if there were a text node whose value
+            //      were the empty string."
+            //
+            // This fake text node is required for a pattern like 'element foo { token }'
+            // to match the input '<foo/>' or '<foo></foo>'
+            self.schema.text_deriv(self.current_step, "")
+        } else {
+            self.current_step
         };
-        let next_pat = match schema.patt(next_pat) {
-            Pat::NotAllowed => return Err(ValidatorError::NotAllowed(evt)),
-            _p => schema.start_tag_close_deriv(next_pat),
-        };
-        Ok(match schema.patt(next_pat) {
-            Pat::NotAllowed => return Err(ValidatorError::NotAllowed(evt)),
-            _p => next_pat, //Self::children_deriv(next_pat, &mut self.schema)
-        })
+        let result = self.schema.end_tag_deriv(next_pid);
+        if self.stack.pop_has_namespaces() {
+            self.schema.ns_context_dirty = true;
+        }
+        if matches!(self.schema.patt(result), Pat::NotAllowed) {
+            return Err(ValidatorError::NotAllowed {
+                span: span.start..span.end,
+                kind: "element-end",
+            });
+        }
+        self.current_step = result;
+        self.last_was_start_element = false;
+        Ok(())
     }
 
-    #[allow(clippy::mutable_key_type)] // false-positive
+    fn handle_empty_element_end(&mut self, span: Span) -> Result<(), ValidatorError> {
+        self.close_element_start(span)?;
+        // The last event was XmlEvent::StartElement with no child elements or child
+        // text nodes.
+        //
+        // Per https://relaxng.org/jclark/derivative.html ,
+        //     "The case where the list of children is empty is
+        //      treated as if there were a text node whose value
+        //      were the empty string."
+        //
+        // This fake text node is required for a pattern like 'element foo { token }'
+        // to match the input '<foo/>' or '<foo></foo>'
+        let p = self.schema.text_deriv(self.current_step, "");
+        let result = self.schema.end_tag_deriv(p);
+        if self.stack.pop_has_namespaces() {
+            self.schema.ns_context_dirty = true;
+        }
+        if matches!(self.schema.patt(result), Pat::NotAllowed) {
+            return Err(ValidatorError::NotAllowed {
+                span: span.start..span.end,
+                kind: "element-end",
+            });
+        }
+        self.current_step = result;
+        self.last_was_start_element = false;
+        Ok(())
+    }
+
+    fn decode_char_ref(value: &[u8]) -> Result<char, ()> {
+        let s = std::str::from_utf8(value).map_err(|_| ())?;
+        let n = if let Some(hex) = s.strip_prefix('x') {
+            u32::from_str_radix(hex, 16).map_err(|_| ())?
+        } else {
+            s.parse::<u32>().map_err(|_| ())?
+        };
+        char::from_u32(n).ok_or(())
+    }
+
+    #[allow(clippy::mutable_key_type)]
     fn heads(&self, id: PatId) -> HashSet<Pat> {
         let mut result = HashSet::new();
         self.head(&mut result, id);
         result
     }
-    #[allow(clippy::mutable_key_type)] // false-positive
+    #[allow(clippy::mutable_key_type)]
     fn head(&self, result: &mut HashSet<Pat>, p: PatId) {
         // https://www.kohsuke.org/relaxng/implbook/Validation1.html#IDATGOO
         let pat = self.schema.patt(p);
@@ -441,7 +582,7 @@ impl<'a> Validator<'a> {
     }
 
     fn describe_expected(&self, expected_patt: PatId) -> String {
-        #[allow(clippy::mutable_key_type)] // false-positive
+        #[allow(clippy::mutable_key_type)]
         let heads = self.heads(expected_patt);
         let mut result = String::new();
         const MAX_ELEMENTS: usize = 4;
@@ -469,7 +610,7 @@ impl<'a> Validator<'a> {
                 // TODO: also provide namespace information; grouping by namespace to make the
                 //       information more succinct
                 let mut desc = String::new();
-                self.describe_nameclass(nameclass, &mut desc);
+                describe_nameclass(nameclass, &mut desc);
                 result.push_str(&desc);
             }
         }
@@ -479,23 +620,21 @@ impl<'a> Validator<'a> {
         // TODO: plus attributes and everything else
         result
     }
-    fn describe_nameclass(&self, nc: &NameClass, desc: &mut String) {
-        describe_nameclass(nc, desc);
-    }
 
     pub fn diagnostic(
         &self,
         name: String,
-        source: String,
+        source: &[u8],
         err: &ValidatorError,
     ) -> (codemap::CodeMap, Vec<codemap_diagnostic::Diagnostic>) {
         let mut map = codemap::CodeMap::new();
-        let file = map.add_file(name, source);
+        let source_str = String::from_utf8_lossy(source).into_owned();
+        let file = map.add_file(name, source_str);
         let mut diagnostics = vec![];
         match err {
             ValidatorError::Xml(err) => {
-                let line = file.line_span(err.pos().row as _);
-                let span = line.subspan(err.pos().row as _, err.pos().row as _);
+                let offset = err.offset;
+                let span = file.span.subspan(offset as _, offset as _);
 
                 let label = codemap_diagnostic::SpanLabel {
                     span,
@@ -505,49 +644,21 @@ impl<'a> Validator<'a> {
 
                 diagnostics.push(codemap_diagnostic::Diagnostic {
                     level: codemap_diagnostic::Level::Error,
-                    message: format!("{err}"),
+                    message: format!("{err:?}"),
                     code: None,
                     spans: vec![label],
                 });
             }
-            ValidatorError::NotAllowed(tok) => {
-                let span = match tok {
-                    Token::Declaration { span, .. }
-                    | Token::ProcessingInstruction { span, .. }
-                    | Token::Comment { span, .. }
-                    | Token::DtdStart { span, .. }
-                    | Token::EmptyDtd { span, .. }
-                    | Token::EntityDeclaration { span, .. }
-                    | Token::DtdEnd { span, .. }
-                    | Token::ElementStart { span, .. }
-                    | Token::Attribute { span, .. }
-                    | Token::ElementEnd { span, .. }
-                    | Token::Cdata { span, .. } => span,
-                    Token::Text { text } => text,
-                };
-                let name = match tok {
-                    Token::Declaration { .. } => "declaration",
-                    Token::ProcessingInstruction { .. } => "processing-instruction",
-                    Token::Comment { .. } => "comment",
-                    Token::DtdStart { .. } => "dtd-start",
-                    Token::EmptyDtd { .. } => "empty-dtd",
-                    Token::EntityDeclaration { .. } => "entity-declaration",
-                    Token::DtdEnd { .. } => "dtd-end",
-                    Token::ElementStart { .. } => "element-start",
-                    Token::Attribute { .. } => "attribute",
-                    Token::ElementEnd { end: _, .. } => "element-end",
-                    Token::Text { .. } => "text",
-                    Token::Cdata { .. } => "cdata",
-                };
+            ValidatorError::NotAllowed { span, kind } => {
                 let label = codemap_diagnostic::SpanLabel {
-                    span: file.span.subspan(span.start() as _, span.end() as _),
+                    span: file.span.subspan(span.start as _, span.end as _),
                     label: Some("Not allowed".to_string()),
                     style: codemap_diagnostic::SpanStyle::Primary,
                 };
 
                 diagnostics.push(codemap_diagnostic::Diagnostic {
                     level: codemap_diagnostic::Level::Error,
-                    message: format!("{name} not expected here"),
+                    message: format!("{kind} not expected here"),
                     code: None,
                     spans: vec![label],
                 });
@@ -565,22 +676,21 @@ impl<'a> Validator<'a> {
                     spans: vec![],
                 });
             }
-            ValidatorError::UndefinedNamespacePrefix { prefix } => {
+            ValidatorError::UndefinedNamespacePrefix { prefix, span } => {
                 let label = codemap_diagnostic::SpanLabel {
-                    span: file.span.subspan(prefix.start() as _, prefix.end() as _),
+                    span: file.span.subspan(span.start as _, span.end as _),
                     label: Some(format!(
-                        "Add an xmlns:{}=\"..\" attribute to define this prefix",
-                        prefix.as_str()
+                        "Add an xmlns:{prefix}=\"..\" attribute to define this prefix"
                     )),
                     style: codemap_diagnostic::SpanStyle::Primary,
                 };
 
                 diagnostics.push(codemap_diagnostic::Diagnostic {
                     level: codemap_diagnostic::Level::Error,
-                    message: format!("The prefix {:?} is not defined", prefix.as_str()),
+                    message: format!("The prefix \"{prefix}\" is not defined"),
                     code: None,
                     spans: vec![label],
-                })
+                });
             }
             ValidatorError::UndefinedEntity { name, span } => {
                 let label = codemap_diagnostic::SpanLabel {
@@ -591,10 +701,10 @@ impl<'a> Validator<'a> {
 
                 diagnostics.push(codemap_diagnostic::Diagnostic {
                     level: codemap_diagnostic::Level::Error,
-                    message: format!("The entity &{name:?}; is not defined"),
+                    message: format!("The entity &{name}; is not defined"),
                     code: None,
                     spans: vec![label],
-                })
+                });
             }
             ValidatorError::InvalidOrUnclosedEntity { span } => {
                 let label = codemap_diagnostic::SpanLabel {
@@ -608,7 +718,59 @@ impl<'a> Validator<'a> {
                     message: "Invalid or unclosed entity reference".to_string(),
                     code: None,
                     spans: vec![label],
-                })
+                });
+            }
+            ValidatorError::InvalidName { span, kind } => {
+                let label = codemap_diagnostic::SpanLabel {
+                    span: file.span.subspan(span.start as _, span.end as _),
+                    label: Some("not a valid XML Name".to_string()),
+                    style: codemap_diagnostic::SpanStyle::Primary,
+                };
+                diagnostics.push(codemap_diagnostic::Diagnostic {
+                    level: codemap_diagnostic::Level::Error,
+                    message: format!("{kind} name is not a valid XML Name"),
+                    code: None,
+                    spans: vec![label],
+                });
+            }
+            ValidatorError::DuplicateAttribute { span } => {
+                let label = codemap_diagnostic::SpanLabel {
+                    span: file.span.subspan(span.start as _, span.end as _),
+                    label: Some("duplicate".to_string()),
+                    style: codemap_diagnostic::SpanStyle::Primary,
+                };
+                diagnostics.push(codemap_diagnostic::Diagnostic {
+                    level: codemap_diagnostic::Level::Error,
+                    message: "duplicate attribute".to_string(),
+                    code: None,
+                    spans: vec![label],
+                });
+            }
+            ValidatorError::TooManyAttributes { span } => {
+                let label = codemap_diagnostic::SpanLabel {
+                    span: file.span.subspan(span.start as _, span.end as _),
+                    label: None,
+                    style: codemap_diagnostic::SpanStyle::Primary,
+                };
+                diagnostics.push(codemap_diagnostic::Diagnostic {
+                    level: codemap_diagnostic::Level::Error,
+                    message: "too many attributes on element (limit: 256)".to_string(),
+                    code: None,
+                    spans: vec![label],
+                });
+            }
+            ValidatorError::InvalidUtf8 { span, kind } => {
+                let label = codemap_diagnostic::SpanLabel {
+                    span: file.span.subspan(span.start as _, span.end as _),
+                    label: Some("invalid UTF-8".to_string()),
+                    style: codemap_diagnostic::SpanStyle::Primary,
+                };
+                diagnostics.push(codemap_diagnostic::Diagnostic {
+                    level: codemap_diagnostic::Level::Error,
+                    message: format!("{kind} contains invalid UTF-8"),
+                    code: None,
+                    spans: vec![label],
+                });
             }
             ValidatorError::TextBufferOverflow => {
                 diagnostics.push(codemap_diagnostic::Diagnostic {
@@ -616,7 +778,15 @@ impl<'a> Validator<'a> {
                     message: "Text content exceeds maximum buffer size".to_string(),
                     code: None,
                     spans: vec![],
-                })
+                });
+            }
+            ValidatorError::Io(e) => {
+                diagnostics.push(codemap_diagnostic::Diagnostic {
+                    level: codemap_diagnostic::Level::Error,
+                    message: format!("I/O error: {e}"),
+                    code: None,
+                    spans: vec![],
+                });
             }
             ValidatorError::Schema(SchemaError::TooManyPatterns) => {
                 diagnostics.push(codemap_diagnostic::Diagnostic {
@@ -624,131 +794,354 @@ impl<'a> Validator<'a> {
                     message: "Schema exceeds maximum number of patterns (65535)".to_string(),
                     code: None,
                     spans: vec![],
-                })
+                });
             }
         }
         (map, diagnostics)
     }
 }
 
-#[derive(Debug)]
-enum Txt<'a> {
-    Text(usize, &'a str),
-    Entity(usize, &'a str),
-    Char(usize, char),
+/// Cold-path classifier for a prefix lookup miss: decide whether the bytes
+/// are invalid UTF-8 (→ `InvalidUtf8`) or just an undefined prefix.
+#[cold]
+fn undefined_or_invalid_prefix(p: &[u8], name_span: Span) -> ValidatorError {
+    match std::str::from_utf8(p) {
+        Ok(s) => ValidatorError::UndefinedNamespacePrefix {
+            prefix: s.to_owned(),
+            span: name_span.start..name_span.end,
+        },
+        Err(_) => ValidatorError::InvalidUtf8 {
+            span: name_span.start..name_span.end,
+            kind: "namespace prefix",
+        },
+    }
 }
 
-fn parse_entities(
-    pos: usize,
-    text: &str,
-) -> impl Iterator<Item = Result<Txt<'_>, ValidatorError<'_>>> {
-    struct Entities<'a> {
-        text: &'a str,
-        pos: usize,
-        offset: usize,
-        in_entity: bool,
-    }
-    impl<'a> Iterator for Entities<'a> {
-        type Item = Result<Txt<'a>, ValidatorError<'a>>;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.offset == self.text.len() {
-                return None;
+/// Map xml-syntax-reader parse errors to validator errors.
+/// `ExpectedName` is promoted to `InvalidName` since it means the tokenizer
+/// encountered an invalid name-start character.
+fn map_parse_error(e: ParseError<ValidatorError>) -> ValidatorError {
+    match e {
+        ParseError::Xml(e) if matches!(e.kind, ErrorKind::ExpectedName(_)) => {
+            let offset = e.offset;
+            ValidatorError::InvalidName {
+                span: offset..offset,
+                kind: "element or attribute",
             }
-            for (i, c) in self.text[self.offset..].char_indices() {
-                if self.in_entity {
-                    if c == ';' {
-                        self.in_entity = false;
-                        let text = &self.text[self.offset..self.offset + i];
-                        let result = if let Some(text) = text.strip_prefix('#') {
-                            numeric_entity(self.offset, text)
-                        } else {
-                            Ok(Txt::Entity(self.offset + self.pos, text))
-                        };
-                        self.offset += i + 1;
-                        return Some(result);
-                    }
-                } else if c == '&' {
-                    self.in_entity = true;
-                    let result = Txt::Text(
-                        self.offset + self.pos,
-                        &self.text[self.offset..self.offset + i],
-                    );
-                    self.offset += i + 1;
-                    return Some(Ok(result));
+        }
+        ParseError::Xml(e) => ValidatorError::Xml(e),
+        ParseError::Visitor(e) => e,
+    }
+}
+
+impl Visitor for Validator {
+    type Error = ValidatorError;
+
+    fn start_tag_open(&mut self, name: QName<'_>) -> Result<(), Self::Error> {
+        self.ensure_ns_context();
+        self.flush_text()?;
+        let prefix = name.prefix().map(|p| self.arena.push_name(p));
+        let local = self.arena.push_name(name.local_name());
+        let name_span = name.span();
+        self.stack.push(prefix, local, name_span);
+        Ok(())
+    }
+
+    fn attribute_name(&mut self, name: QName<'_>) -> Result<(), Self::Error> {
+        self.current_attr_prefix = name.prefix().map(|p| self.arena.push_name(p));
+        self.current_attr_local = self.arena.push_name(name.local_name());
+        self.current_attr_name_span = name.span();
+        self.current_attr_value_start = self.arena.begin_value();
+        Ok(())
+    }
+
+    fn attribute_value(&mut self, value: &[u8], span: Span) -> Result<(), Self::Error> {
+        // Validate UTF-8 at the boundary so the arena's invariant holds:
+        // every byte in an attribute-value range is valid UTF-8.
+        std::str::from_utf8(value).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind: "attribute value",
+        })?;
+        self.arena.push_value_bytes(value);
+        Ok(())
+    }
+
+    fn attribute_entity_ref(&mut self, name: &[u8], span: Span) -> Result<(), Self::Error> {
+        let name_str = std::str::from_utf8(name).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind: "entity name",
+        })?;
+        if let Some(val) = self.entity_definitions.get(name_str) {
+            let val = val.clone();
+            self.arena.push_value_str(&val);
+            Ok(())
+        } else {
+            Err(ValidatorError::UndefinedEntity {
+                name: name_str.to_owned(),
+                span: span.start..span.end,
+            })
+        }
+    }
+
+    fn attribute_char_ref(&mut self, value: &[u8], span: Span) -> Result<(), Self::Error> {
+        let c =
+            Self::decode_char_ref(value).map_err(|()| ValidatorError::InvalidOrUnclosedEntity {
+                span: span.start..span.end,
+            })?;
+        self.arena.push_value_char(c);
+        Ok(())
+    }
+
+    fn attribute_end(&mut self, _span: Span) -> Result<(), Self::Error> {
+        const MAX_ATTRIBUTES: usize = 256;
+
+        let prefix = self.current_attr_prefix.take();
+        let local = self.current_attr_local;
+        let value = self.arena.finish_value(self.current_attr_value_start);
+        let name_span = self.current_attr_name_span;
+
+        // Check for namespace declarations using arena data
+        let is_xmlns_prefix = prefix.is_some_and(|r| self.arena.get_name(r) == b"xmlns");
+        let is_default_xmlns = prefix.is_none() && self.arena.get_name(local) == b"xmlns";
+
+        // Enforce attribute count limit
+        let total_attrs = self.stack.current_attr_count() + self.stack.current_ns_count();
+        if total_attrs >= MAX_ATTRIBUTES {
+            return Err(ValidatorError::TooManyAttributes {
+                span: name_span.start..name_span.end,
+            });
+        }
+
+        // Check for duplicate attributes (comparing raw name bytes in the arena)
+        let new_prefix = prefix.map(|r| self.arena.get_name(r));
+        let new_local = self.arena.get_name(local);
+        let attr_start = self.stack.scopes.last().unwrap().attr_start as usize;
+        for attr in &self.stack.attrs[attr_start..] {
+            let existing_prefix = attr.prefix.map(|r| self.arena.get_name(r));
+            let existing_local = self.arena.get_name(attr.local);
+            if existing_prefix == new_prefix && existing_local == new_local {
+                return Err(ValidatorError::DuplicateAttribute {
+                    span: name_span.start..name_span.end,
+                });
+            }
+        }
+        // Also check against namespace declarations (xmlns:foo vs xmlns:foo)
+        if is_xmlns_prefix || is_default_xmlns {
+            let ns_start = self.stack.scopes.last().unwrap().ns_decl_start as usize;
+            for decl in &self.stack.ns_declarations[ns_start..] {
+                let matches = if is_xmlns_prefix {
+                    decl.prefix.as_bytes() == new_local
+                } else {
+                    decl.prefix.is_empty()
+                };
+                if matches {
+                    return Err(ValidatorError::DuplicateAttribute {
+                        span: name_span.start..name_span.end,
+                    });
                 }
             }
-            if self.in_entity {
-                Some(Err(ValidatorError::InvalidOrUnclosedEntity {
-                    span: self.pos + self.offset - 1..self.pos + self.offset,
-                }))
+        }
+
+        if is_xmlns_prefix || is_default_xmlns {
+            self.schema.ns_context_dirty = true;
+            let prefix_bytes: &[u8] = if is_xmlns_prefix {
+                self.arena.get_name(local)
             } else {
-                let result = Txt::Text(self.offset + self.pos, &self.text[self.offset..]);
-                self.offset = self.text.len();
-                Some(Ok(result))
-            }
-        }
-    }
-    fn numeric_entity(pos: usize, text: &str) -> Result<Txt<'_>, ValidatorError<'_>> {
-        if text.is_empty() {
-            return Err(ValidatorError::InvalidOrUnclosedEntity { span: pos..pos });
-        }
-        let c = if let Some(text) = text.strip_prefix('x') {
-            let pos = pos + 1;
-            if text.is_empty() {
-                return Err(ValidatorError::InvalidOrUnclosedEntity { span: pos..pos });
-            }
-            u32::from_str_radix(text, 16)
-                .map_err(|_e| ValidatorError::InvalidOrUnclosedEntity { span: pos..pos })?
+                b""
+            };
+            let uri = self.arena.get_value(value).to_owned();
+            self.stack.add_namespace(prefix_bytes, name_span, uri)?;
         } else {
-            text.parse()
-                .map_err(|_e| ValidatorError::InvalidOrUnclosedEntity { span: pos..pos })?
-        };
-        Ok(Txt::Char(
-            pos,
-            std::char::from_u32(c)
-                .ok_or(ValidatorError::InvalidOrUnclosedEntity { span: pos..pos })?,
-        ))
+            self.stack.add_attr(prefix, local, name_span, value);
+        }
+        Ok(())
     }
-    Entities {
-        text,
-        pos,
-        offset: 0,
-        in_entity: false,
+
+    fn start_tag_close(&mut self, span: Span) -> Result<(), Self::Error> {
+        self.close_element_start(span)
     }
+
+    fn empty_element_end(&mut self, span: Span) -> Result<(), Self::Error> {
+        self.handle_empty_element_end(span)
+    }
+
+    fn end_tag(&mut self, name: QName<'_>) -> Result<(), Self::Error> {
+        self.handle_end_tag(name.span())
+    }
+
+    fn characters(&mut self, text: &[u8], span: Span) -> Result<(), Self::Error> {
+        self.append_text_bytes(text, span, "text")
+    }
+
+    fn entity_ref(&mut self, name: &[u8], span: Span) -> Result<(), Self::Error> {
+        let name_str = std::str::from_utf8(name).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind: "entity name",
+        })?;
+        if let Some(val) = self.entity_definitions.get(name_str) {
+            let val = val.clone();
+            self.append_validated_text(&val, span)
+        } else {
+            Err(ValidatorError::UndefinedEntity {
+                name: name_str.to_owned(),
+                span: span.start..span.end,
+            })
+        }
+    }
+
+    fn char_ref(&mut self, value: &[u8], span: Span) -> Result<(), Self::Error> {
+        let c =
+            Self::decode_char_ref(value).map_err(|()| ValidatorError::InvalidOrUnclosedEntity {
+                span: span.start..span.end,
+            })?;
+        let mut buf = [0u8; 4];
+        let s = c.encode_utf8(&mut buf);
+        self.append_validated_text(s, span)
+    }
+
+    fn cdata_content(&mut self, text: &[u8], span: Span) -> Result<(), Self::Error> {
+        self.append_text_bytes(text, span, "CDATA content")
+    }
+
+    // DTD entity declarations
+    fn entity_decl_start(
+        &mut self,
+        name: &[u8],
+        kind: EntityKind,
+        span: Span,
+    ) -> Result<(), Self::Error> {
+        if kind == EntityKind::General {
+            let name_str = std::str::from_utf8(name).map_err(|_| ValidatorError::InvalidUtf8 {
+                span: span.start..span.end,
+                kind: "entity name",
+            })?;
+            self.stack.pending_entity_name = Some(name_str.to_owned());
+            self.stack.pending_entity_value = Some(String::new());
+        }
+        Ok(())
+    }
+
+    fn entity_decl_value(&mut self, value: &[u8], span: Span) -> Result<(), Self::Error> {
+        let s = std::str::from_utf8(value).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind: "entity value",
+        })?;
+        if let Some(ref mut val) = self.stack.pending_entity_value {
+            val.push_str(s);
+        }
+        Ok(())
+    }
+
+    fn entity_decl_char_ref(&mut self, value: &[u8], span: Span) -> Result<(), Self::Error> {
+        let c =
+            Self::decode_char_ref(value).map_err(|()| ValidatorError::InvalidOrUnclosedEntity {
+                span: span.start..span.end,
+            })?;
+        if let Some(ref mut val) = self.stack.pending_entity_value {
+            val.push(c);
+        }
+        Ok(())
+    }
+
+    fn entity_decl_entity_ref(&mut self, name: &[u8], span: Span) -> Result<(), Self::Error> {
+        let name_str = std::str::from_utf8(name).map_err(|_| ValidatorError::InvalidUtf8 {
+            span: span.start..span.end,
+            kind: "entity name",
+        })?;
+        if let Some(resolved) = self.entity_definitions.get(name_str) {
+            let resolved = resolved.clone();
+            if let Some(ref mut val) = self.stack.pending_entity_value {
+                val.push_str(&resolved);
+            }
+            Ok(())
+        } else {
+            Err(ValidatorError::UndefinedEntity {
+                name: name_str.to_owned(),
+                span: span.start..span.end,
+            })
+        }
+    }
+
+    fn entity_decl_end(&mut self, _span: Span) -> Result<(), Self::Error> {
+        if let (Some(name), Some(value)) = (
+            self.stack.pending_entity_name.take(),
+            self.stack.pending_entity_value.take(),
+        ) {
+            self.entity_definitions.insert(name, value);
+        }
+        Ok(())
+    }
+}
+
+/// Attribute with name and value stored as ranges into the `TagArena`.
+struct Attr {
+    prefix: Option<NameRange>,
+    local: NameRange,
+    name_span: Span,
+    value: ValueRange,
+}
+
+/// A namespace prefix→URI binding in the flat declaration stack.
+struct NsDecl {
+    prefix: String,
+    namespace_uri: String,
+}
+
+/// Per-element metadata on the scope stack. No per-element Vec allocations.
+struct ElementScope {
+    prefix: Option<NameRange>,
+    local: NameRange,
+    name_span: Span,
+    /// Index into `ns_declarations` where this element's declarations start.
+    ns_decl_start: u32,
+    /// True if this scope declared a default namespace (xmlns="...").
+    has_default_ns: bool,
+    /// Index into the reusable `attrs` vec where this element's attributes start.
+    attr_start: u32,
 }
 
 #[derive(Default)]
-struct ElementStack<'a> {
-    elements: Vec<ElementState<'a>>,
+struct ElementStack {
+    /// Element scope stack.
+    scopes: Vec<ElementScope>,
+    /// Flat list of all prefix→URI namespace declarations across all depths.
+    /// Each element scope owns the range `[scope.ns_decl_start .. next_scope.ns_decl_start]`.
+    /// Pop truncates back to the scope's start index.
+    ns_declarations: Vec<NsDecl>,
+    /// Cached default namespace URI. Updated eagerly on declaration, recomputed
+    /// on pop only if the popped scope had a default namespace declaration.
+    cached_default_ns: String,
+    /// Reusable buffer for attributes of the current element. Cleared per element.
+    attrs: Vec<Attr>,
+    // Temporary state for DTD entity declarations
+    pending_entity_name: Option<String>,
+    pending_entity_value: Option<String>,
 }
 
-impl<'a> ElementStack<'a> {
-    fn lookup_namespace_uri(&self, prefix: &str) -> Option<StrSpan<'a>> {
-        if prefix == "xml" {
-            return Some(StrSpan::from("http://www.w3.org/XML/1998/namespace"));
+impl ElementStack {
+    /// Byte-compare lookup. Stored prefixes are guaranteed valid UTF-8
+    /// (validated at `add_namespace`), so a hit implies the input bytes are
+    /// also valid UTF-8 by transitivity.
+    fn lookup_namespace_uri(&self, prefix: &[u8]) -> Option<&str> {
+        if prefix == b"xml" {
+            return Some("http://www.w3.org/XML/1998/namespace");
         }
-        self.elements
+        // Walk declarations in reverse (most recent first)
+        self.ns_declarations
             .iter()
             .rev()
-            .find_map(|elem| elem.lookup_namespace_uri(prefix))
+            .find(|d| d.prefix.as_bytes() == prefix)
+            .map(|d| d.namespace_uri.as_str())
     }
 
     fn capture_ns_context(&self) -> NsContext {
         let mut default_ns = String::new();
         let mut bindings = Vec::new();
-        for elem in &self.elements {
-            for ns in &elem.namespaces {
-                if ns.prefix.as_str().is_empty() {
-                    // Default namespace (xmlns="...")
-                    default_ns = ns.namespace_uri.as_str().to_string();
-                } else {
-                    // Prefixed namespace (xmlns:prefix="...")
-                    bindings.push((
-                        ns.prefix.as_str().to_string(),
-                        ns.namespace_uri.as_str().to_string(),
-                    ));
-                }
+        for decl in &self.ns_declarations {
+            if decl.prefix.is_empty() {
+                default_ns = decl.namespace_uri.clone();
+            } else {
+                bindings.push((decl.prefix.clone(), decl.namespace_uri.clone()));
             }
         }
         NsContext {
@@ -759,153 +1152,127 @@ impl<'a> ElementStack<'a> {
 
     fn resolve_element_namespace(
         &self,
-        prefix: StrSpan<'a>,
-    ) -> Result<Option<StrSpan<'a>>, ValidatorError<'a>> {
-        if prefix.as_str() == "" {
-            // For elements, empty prefix means look up the default namespace (xmlns="...")
-            Ok(self.lookup_namespace_uri(""))
-        } else {
-            Ok(Some(self.lookup_namespace_uri(&prefix).ok_or(
-                ValidatorError::UndefinedNamespacePrefix { prefix },
-            )?))
+        prefix: Option<&[u8]>,
+        name_span: Span,
+    ) -> Result<Option<&str>, ValidatorError> {
+        match prefix {
+            None => {
+                // For elements, empty prefix means look up the default namespace (xmlns="...")
+                if self.cached_default_ns.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(self.cached_default_ns.as_str()))
+                }
+            }
+            Some(p) => match self.lookup_namespace_uri(p) {
+                Some(uri) => Ok(Some(uri)),
+                None => Err(undefined_or_invalid_prefix(p, name_span)),
+            },
         }
     }
 
     fn resolve_attribute_namespace(
         &self,
-        prefix: StrSpan<'a>,
-    ) -> Result<Option<StrSpan<'a>>, ValidatorError<'a>> {
-        if prefix.as_str() == "" {
+        prefix: Option<&[u8]>,
+        name_span: Span,
+    ) -> Result<Option<&str>, ValidatorError> {
+        match prefix {
             // Per XML Namespaces spec, unprefixed attributes have no namespace
-            Ok(None)
-        } else {
-            Ok(Some(self.lookup_namespace_uri(&prefix).ok_or(
-                ValidatorError::UndefinedNamespacePrefix { prefix },
-            )?))
+            None => Ok(None),
+            Some(p) => match self.lookup_namespace_uri(p) {
+                Some(uri) => Ok(Some(uri)),
+                None => Err(undefined_or_invalid_prefix(p, name_span)),
+            },
         }
     }
 
-    fn push(&mut self, prefix: StrSpan<'a>, local: StrSpan<'a>, _span: StrSpan<'a>) {
-        self.elements.push(ElementState {
+    fn push(&mut self, prefix: Option<NameRange>, local: NameRange, name_span: Span) {
+        let ns_decl_start = self.ns_declarations.len() as u32;
+        let attr_start = self.attrs.len() as u32;
+        self.scopes.push(ElementScope {
             prefix,
             local,
-            namespaces: vec![],
-            attributes: vec![],
-        })
+            name_span,
+            ns_decl_start,
+            has_default_ns: false,
+            attr_start,
+        });
     }
+
     fn pop_has_namespaces(&mut self) -> bool {
-        self.elements
-            .pop()
-            .is_some_and(|e| !e.namespaces.is_empty())
+        let scope = self.scopes.pop().unwrap();
+        let had_ns = (scope.ns_decl_start as usize) < self.ns_declarations.len();
+        self.ns_declarations.truncate(scope.ns_decl_start as usize);
+        self.attrs.truncate(scope.attr_start as usize);
+        // Recompute cached default namespace if the popped scope declared one
+        if scope.has_default_ns {
+            self.cached_default_ns = self
+                .ns_declarations
+                .iter()
+                .rev()
+                .find(|d| d.prefix.is_empty())
+                .map(|d| d.namespace_uri.clone())
+                .unwrap_or_default();
+        }
+        had_ns
     }
+
+    /// Validates prefix UTF-8 once, here. Anchors the invariant that every
+    /// stored `NsDecl.prefix` is valid UTF-8, so hot-path lookups can byte-compare
+    /// without revalidating.
+    fn add_namespace(
+        &mut self,
+        prefix_bytes: &[u8],
+        prefix_span: Span,
+        uri: String,
+    ) -> Result<(), ValidatorError> {
+        let prefix = if prefix_bytes.is_empty() {
+            String::new()
+        } else {
+            std::str::from_utf8(prefix_bytes)
+                .map_err(|_| ValidatorError::InvalidUtf8 {
+                    span: prefix_span.start..prefix_span.end,
+                    kind: "namespace prefix",
+                })?
+                .to_owned()
+        };
+        if prefix.is_empty() {
+            self.cached_default_ns = uri.clone();
+            self.scopes.last_mut().unwrap().has_default_ns = true;
+        }
+        self.ns_declarations.push(NsDecl {
+            prefix,
+            namespace_uri: uri,
+        });
+        Ok(())
+    }
+
     fn add_attr(
         &mut self,
-        prefix: StrSpan<'a>,
-        local: StrSpan<'a>,
-        value: StrSpan<'a>,
-        span: StrSpan<'a>,
+        prefix: Option<NameRange>,
+        local: NameRange,
+        name_span: Span,
+        value: ValueRange,
     ) {
-        if prefix.as_str() == "xmlns" {
-            self.elements.last_mut().unwrap().namespaces.push(Ns {
-                prefix: local,
-                namespace_uri: value,
-            })
-        } else if prefix.as_str() == "" && local.as_str() == "xmlns" {
-            self.elements.last_mut().unwrap().namespaces.push(Ns {
-                prefix,
-                namespace_uri: value,
-            })
-        } else {
-            self.elements
-                .last_mut()
-                .unwrap()
-                .attributes
-                .push(UnresolvedAttr {
-                    prefix,
-                    local,
-                    value,
-                    span,
-                })
-        }
+        self.attrs.push(Attr {
+            prefix,
+            local,
+            name_span,
+            value,
+        });
     }
-    fn current_element(&self) -> Result<ResolvedElement<'a>, ValidatorError<'a>> {
-        let curr = self.elements.last().unwrap();
-        let namespace_uri = self.resolve_element_namespace(curr.prefix)?;
-        Ok(ResolvedElement {
-            name: QualifiedName {
-                namespace_uri: namespace_uri.map(|s| s.as_str()),
-                local_name: curr.local.as_str(),
-            },
-            raw_prefix: curr.prefix,
-            raw_local: curr.local,
-        })
+
+    /// Number of attributes on the current element.
+    fn current_attr_count(&self) -> usize {
+        let start = self.scopes.last().unwrap().attr_start as usize;
+        self.attrs.len() - start
     }
-    fn current_attributes(&self) -> Result<Vec<ResolvedAttr<'a>>, ValidatorError<'a>> {
-        self.elements
-            .last()
-            .unwrap()
-            .attributes
-            .iter()
-            .map(move |unresolved| {
-                let namespace_uri = self.resolve_attribute_namespace(unresolved.prefix)?;
-                Ok(ResolvedAttr {
-                    name: QualifiedName {
-                        namespace_uri: namespace_uri.map(|s| s.as_str()),
-                        local_name: unresolved.local.as_str(),
-                    },
-                    value: unresolved.value.as_str(),
-                    raw_prefix: unresolved.prefix,
-                    raw_local: unresolved.local,
-                    raw_value: unresolved.value,
-                    raw_span: unresolved.span,
-                })
-            })
-            .collect()
+
+    /// Number of namespace declarations on the current element.
+    fn current_ns_count(&self) -> usize {
+        let start = self.scopes.last().unwrap().ns_decl_start as usize;
+        self.ns_declarations.len() - start
     }
-}
-
-/// Resolved element with both &str QualifiedName (for derivatives) and raw StrSpan (for errors).
-struct ResolvedElement<'a> {
-    name: QualifiedName<'a>,
-    raw_prefix: StrSpan<'a>,
-    raw_local: StrSpan<'a>,
-}
-
-/// Resolved attribute with both &str QualifiedName (for derivatives) and raw StrSpan (for errors).
-struct ResolvedAttr<'a> {
-    name: QualifiedName<'a>,
-    value: &'a str,
-    raw_prefix: StrSpan<'a>,
-    raw_local: StrSpan<'a>,
-    raw_value: StrSpan<'a>,
-    raw_span: StrSpan<'a>,
-}
-
-struct UnresolvedAttr<'a> {
-    prefix: StrSpan<'a>,
-    local: StrSpan<'a>,
-    value: StrSpan<'a>,
-    span: StrSpan<'a>,
-}
-struct ElementState<'a> {
-    prefix: StrSpan<'a>,
-    local: StrSpan<'a>,
-    namespaces: Vec<Ns<'a>>,
-    attributes: Vec<UnresolvedAttr<'a>>,
-}
-
-impl<'a> ElementState<'a> {
-    fn lookup_namespace_uri(&self, prefix: &str) -> Option<StrSpan<'a>> {
-        self.namespaces
-            .iter()
-            .find(|ns| ns.prefix.as_str() == prefix)
-            .map(|ns| ns.namespace_uri)
-    }
-}
-
-struct Ns<'a> {
-    prefix: StrSpan<'a>,
-    namespace_uri: StrSpan<'a>,
 }
 
 #[cfg(test)]
@@ -952,47 +1319,37 @@ mod tests {
         }
 
         fn valid(&self, xml: &str) {
-            let reader = xmlparser::Tokenizer::from(xml);
-            let mut v = Validator::new(self.schema.clone(), reader).unwrap();
-            while let Some(i) = v.validate_next() {
-                if let Err(err) = i {
-                    let (map, d) = v.diagnostic("valid.xml".to_string(), xml.to_string(), &err);
-                    let mut emitter = codemap_diagnostic::Emitter::stderr(
-                        codemap_diagnostic::ColorConfig::Auto,
-                        Some(&map),
-                    );
-                    emitter.emit(&d[..]);
-                    panic!("{err:?}");
-                }
+            let mut v = Validator::new(self.schema.clone()).unwrap();
+            if let Err(err) = v.validate(xml.as_bytes()) {
+                let (map, d) = v.diagnostic("valid.xml".to_string(), xml.as_bytes(), &err);
+                let mut emitter = codemap_diagnostic::Emitter::stderr(
+                    codemap_diagnostic::ColorConfig::Auto,
+                    Some(&map),
+                );
+                emitter.emit(&d[..]);
+                panic!("{err:?}");
             }
         }
 
         fn valid_with_coverage(&self, xml: &str) -> super::CoverageReport {
-            let reader = xmlparser::Tokenizer::from(xml);
-            let mut v = Validator::new_with_coverage(self.schema.clone(), reader).unwrap();
-            while let Some(i) = v.validate_next() {
-                if let Err(err) = i {
-                    let (map, d) = v.diagnostic("valid.xml".to_string(), xml.to_string(), &err);
-                    let mut emitter = codemap_diagnostic::Emitter::stderr(
-                        codemap_diagnostic::ColorConfig::Auto,
-                        Some(&map),
-                    );
-                    emitter.emit(&d[..]);
-                    panic!("{err:?}");
-                }
+            let mut v = Validator::new_with_coverage(self.schema.clone()).unwrap();
+            if let Err(err) = v.validate(xml.as_bytes()) {
+                let (map, d) = v.diagnostic("valid.xml".to_string(), xml.as_bytes(), &err);
+                let mut emitter = codemap_diagnostic::Emitter::stderr(
+                    codemap_diagnostic::ColorConfig::Auto,
+                    Some(&map),
+                );
+                emitter.emit(&d[..]);
+                panic!("{err:?}");
             }
             v.coverage_report().expect("coverage should be enabled")
         }
 
         fn invalid(&self, xml: &str) {
-            let reader = xmlparser::Tokenizer::from(xml);
-            let mut v = Validator::new(self.schema.clone(), reader).unwrap();
-            while let Some(i) = v.validate_next() {
-                if let Err(_err) = i {
-                    return;
-                }
+            let mut v = Validator::new(self.schema.clone()).unwrap();
+            if v.validate(xml.as_bytes()).is_ok() {
+                panic!("Invalid input was accepted by the validator")
             }
-            panic!("Invalid input was accepted by the validator")
         }
     }
 
@@ -1022,22 +1379,11 @@ mod tests {
             }
         };
 
-        let reader = xmlparser::Tokenizer::from(doc);
-        let mut v = Validator::new(schema.start, reader).unwrap();
+        let mut v = Validator::new(schema.start).unwrap();
         println!("====");
         v.schema.d(v.current_step).unwrap();
         println!("====");
-        let mut fail = None;
-        while let Some(i) = v.validate_next() {
-            if let Err(err) = i {
-                fail = Some(format!("{err:?}"));
-                break;
-            }
-        }
-        if let Some(err) = fail {
-            return Err(format!("{err:?}"));
-        }
-        Ok(())
+        v.validate(doc.as_bytes()).map_err(|e| format!("{e:?}"))
     }
 
     #[test]
@@ -1204,10 +1550,7 @@ mod tests {
 
     #[test]
     fn parse_entities() {
-        let mut iter = super::parse_entities(0, "foo &bar; blat");
-        assert_matches!(iter.next(), Some(Ok(super::Txt::Text(0, "foo "))));
-        assert_matches!(iter.next(), Some(Ok(super::Txt::Entity(5, "bar"))));
-        assert_matches!(iter.next(), Some(Ok(super::Txt::Text(9, " blat"))));
+        Fixture::correct("start = element a { text }").valid("<a>foo &amp; bar</a>");
     }
 
     #[test]
@@ -1359,15 +1702,9 @@ mod tests {
         let f = Fixture::correct(schema);
 
         let xml = "<root xmlns=\"urn:foo\"><wrong xmlns=\"urn:bar\">text</wrong></root>";
-        let reader = xmlparser::Tokenizer::from(xml);
-        let mut v = Validator::new(f.schema.clone(), reader).unwrap();
-        let mut diagnostics = vec![];
-        while let Some(i) = v.validate_next() {
-            if let Err(err) = i {
-                let (_, d) = v.diagnostic("test.xml".to_string(), xml.to_string(), &err);
-                diagnostics.extend(d);
-            }
-        }
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(xml.as_bytes()).unwrap_err();
+        let (_, diagnostics) = v.diagnostic("test.xml".to_string(), xml.as_bytes(), &err);
         let messages: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
         assert!(
             messages.iter().any(|m| m.contains("{urn:foo}child")),
@@ -1381,15 +1718,9 @@ mod tests {
         let f = Fixture::correct(schema);
 
         let xml = "<root><wrong>text</wrong></root>";
-        let reader = xmlparser::Tokenizer::from(xml);
-        let mut v = Validator::new(f.schema.clone(), reader).unwrap();
-        let mut diagnostics = vec![];
-        while let Some(i) = v.validate_next() {
-            if let Err(err) = i {
-                let (_, d) = v.diagnostic("test.xml".to_string(), xml.to_string(), &err);
-                diagnostics.extend(d);
-            }
-        }
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(xml.as_bytes()).unwrap_err();
+        let (_, diagnostics) = v.diagnostic("test.xml".to_string(), xml.as_bytes(), &err);
         let messages: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
         assert!(
             messages
@@ -1402,11 +1733,158 @@ mod tests {
     #[test]
     fn coverage_disabled_by_default() {
         let f = Fixture::correct("start = element a { empty }");
-        let reader = xmlparser::Tokenizer::from("<a/>");
-        let mut v = Validator::new(f.schema.clone(), reader).unwrap();
-        while let Some(i) = v.validate_next() {
-            i.unwrap();
-        }
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        v.validate(b"<a/>").unwrap();
         assert!(v.coverage_report().is_none());
+    }
+
+    #[test]
+    fn invalid_element_name_reported_as_invalid_name() {
+        // Schema accepts any element name, but "b!ad" is not a valid XML NCName
+        // (xml-syntax-reader accepts '!' in names since it's not a name-terminator)
+        let f = Fixture::correct("start = element * { empty }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(b"<b!ad/>").unwrap_err();
+        assert_matches!(
+            err,
+            super::ValidatorError::InvalidName {
+                kind: "element",
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_name_start_char_reported_as_invalid_name() {
+        // "1bad" starts with a digit — rejected by xml-syntax-reader as ExpectedName,
+        // which the validator maps to InvalidName (not Xml error)
+        let f = Fixture::correct("start = element a { empty }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(b"<1bad/>").unwrap_err();
+        assert_matches!(err, super::ValidatorError::InvalidName { .. });
+    }
+
+    #[test]
+    fn invalid_attribute_name_reported_as_invalid_name() {
+        // Schema requires an attribute with a specific name plus allows any others;
+        // "b@d" is not a valid NCName
+        let f = Fixture::correct(
+            "start = element a { attribute x { text }, attribute * - x { text }* }",
+        );
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(b"<a x=\"v\" b@d=\"x\"/>").unwrap_err();
+        assert_matches!(
+            err,
+            super::ValidatorError::InvalidName {
+                kind: "attribute",
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_attribute_rejected() {
+        let f = Fixture::correct("start = element a { attribute x { text } }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v.validate(b"<a x=\"1\" x=\"2\"/>").unwrap_err();
+        assert_matches!(err, super::ValidatorError::DuplicateAttribute { .. });
+    }
+
+    #[test]
+    fn duplicate_xmlns_rejected() {
+        let f = Fixture::correct("default namespace = \"urn:x\" start = element a { empty }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let err = v
+            .validate(b"<a xmlns=\"urn:x\" xmlns=\"urn:y\"/>")
+            .unwrap_err();
+        assert_matches!(err, super::ValidatorError::DuplicateAttribute { .. });
+    }
+
+    #[test]
+    fn invalid_utf8_in_text_rejected() {
+        // Schema permits any text — we must still reject malformed UTF-8.
+        let f = Fixture::correct("start = element a { text }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        // 0xC0 is an invalid UTF-8 lead byte (overlong encoding).
+        let bad = b"<a>hello\xC0world</a>";
+        let err = v.validate(bad).unwrap_err();
+        assert_matches!(err, super::ValidatorError::InvalidUtf8 { kind: "text", .. });
+    }
+
+    #[test]
+    fn invalid_utf8_in_text_under_fixed_point_pattern_rejected() {
+        // `text` is a fixed-point — the validator's hot path skips the buffer
+        // copy and `text_deriv` walk, but Option A keeps the UTF-8 check.
+        let f = Fixture::correct("start = element a { text }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        // Lone continuation byte — invalid UTF-8.
+        let bad = b"<a>\x80</a>";
+        let err = v.validate(bad).unwrap_err();
+        assert_matches!(err, super::ValidatorError::InvalidUtf8 { kind: "text", .. });
+    }
+
+    #[test]
+    fn invalid_utf8_in_cdata_rejected() {
+        let f = Fixture::correct("start = element a { text }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let bad = b"<a><![CDATA[\xFF]]></a>";
+        let err = v.validate(bad).unwrap_err();
+        assert_matches!(
+            err,
+            super::ValidatorError::InvalidUtf8 {
+                kind: "CDATA content",
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_in_attribute_value_rejected() {
+        // Schema accepts any text in attribute — must still reject malformed UTF-8.
+        let f = Fixture::correct("start = element a { attribute x { text } }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let bad = b"<a x=\"hi\xC0there\"/>";
+        let err = v.validate(bad).unwrap_err();
+        assert_matches!(
+            err,
+            super::ValidatorError::InvalidUtf8 {
+                kind: "attribute value",
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_in_xmlns_uri_rejected() {
+        // xmlns URI is an attribute value — bad UTF-8 must be rejected even
+        // though no schema URI comparison would ever hit it.
+        let f = Fixture::correct("start = element a { empty }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let bad = b"<a xmlns:foo=\"urn:\xFFbad\"/>";
+        let err = v.validate(bad).unwrap_err();
+        assert_matches!(
+            err,
+            super::ValidatorError::InvalidUtf8 {
+                kind: "attribute value",
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn text_not_allowed_diagnostic_uses_text_span() {
+        // When buffered text is rejected, the error span should cover the text
+        // run, not the surrounding element.
+        let f = Fixture::correct("start = element a { empty }");
+        let mut v = Validator::new(f.schema.clone()).unwrap();
+        let xml = b"<a>nope</a>";
+        let err = v.validate(xml).unwrap_err();
+        let span = match err {
+            super::ValidatorError::NotAllowed { span, kind: "text" } => span,
+            other => panic!("expected NotAllowed text error, got {other:?}"),
+        };
+        // "nope" starts at byte 3 in the document.
+        assert_eq!(span.start, 3, "span start should point at the text");
+        assert_eq!(span.end, 7, "span end should be after the text");
     }
 }

--- a/relaxng-validator/src/nameclass.rs
+++ b/relaxng-validator/src/nameclass.rs
@@ -4,7 +4,10 @@ use relaxng_model::model::NameClass;
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct QualifiedName<'a> {
     pub(crate) namespace_uri: Option<&'a str>,
-    pub(crate) local_name: &'a str,
+    /// Local name as raw bytes. For `Named` matches, byte equality against the
+    /// schema's UTF-8 name is sufficient. For wildcard matches (`AnyName`/`NsName`),
+    /// `contains()` validates that this is a legal XML NCName.
+    pub(crate) local_name: &'a [u8],
 }
 
 fn is_ns_match(namespace_uri: &str, target_namespace: Option<&str>) -> bool {
@@ -15,22 +18,78 @@ fn is_ns_match(namespace_uri: &str, target_namespace: Option<&str>) -> bool {
     }
 }
 
-pub(crate) fn contains(nc: &NameClass, target_name: QualifiedName) -> bool {
+/// Check if `bytes` is a valid XML NCName (Name without colons).
+/// See <https://www.w3.org/TR/xml-names/#NT-NCName>.
+pub(crate) fn is_ncname(bytes: &[u8]) -> bool {
+    let s = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if is_name_start_char(c) => {}
+        _ => return false,
+    }
+    chars.all(is_name_char)
+}
+
+/// XML NameStartChar (excluding ':'): Letter | '_'
+/// See <https://www.w3.org/TR/xml/#NT-NameStartChar>.
+fn is_name_start_char(c: char) -> bool {
+    matches!(c,
+        'A'..='Z'
+        | '_'
+        | 'a'..='z'
+        | '\u{C0}'..='\u{D6}'
+        | '\u{D8}'..='\u{F6}'
+        | '\u{F8}'..='\u{2FF}'
+        | '\u{370}'..='\u{37D}'
+        | '\u{37F}'..='\u{1FFF}'
+        | '\u{200C}'..='\u{200D}'
+        | '\u{2070}'..='\u{218F}'
+        | '\u{2C00}'..='\u{2FEF}'
+        | '\u{3001}'..='\u{D7FF}'
+        | '\u{F900}'..='\u{FDCF}'
+        | '\u{FDF0}'..='\u{FFFD}'
+        | '\u{10000}'..='\u{EFFFF}'
+    )
+}
+
+/// XML NameChar (excluding ':'): NameStartChar | '-' | '.' | digit | combining/extender
+/// See <https://www.w3.org/TR/xml/#NT-NameChar>.
+fn is_name_char(c: char) -> bool {
+    is_name_start_char(c)
+        || matches!(c,
+            '-'
+            | '.'
+            | '0'..='9'
+            | '\u{B7}'
+            | '\u{0300}'..='\u{036F}'
+            | '\u{203F}'..='\u{2040}'
+        )
+}
+
+pub(crate) fn contains(nc: &NameClass, target_name: &QualifiedName) -> bool {
     match nc {
         NameClass::Named {
             namespace_uri,
             name,
         } => {
-            if let Some(ref target_namespace) = target_name.namespace_uri {
-                *target_namespace == namespace_uri && target_name.local_name == name
+            // Byte equality: if the schema name is a valid NCName (guaranteed by
+            // the schema compiler), matching bytes implies a valid name.
+            if let Some(target_namespace) = target_name.namespace_uri {
+                target_namespace == namespace_uri && target_name.local_name == name.as_bytes()
             } else {
-                namespace_uri.is_empty() && target_name.local_name == name
+                namespace_uri.is_empty() && target_name.local_name == name.as_bytes()
             }
         }
         NameClass::NsName {
             namespace_uri,
             except,
         } => {
+            if !is_ncname(target_name.local_name) {
+                return false;
+            }
             if is_ns_match(namespace_uri, target_name.namespace_uri) {
                 if let Some(except_nameclass) = except {
                     !contains(except_nameclass, target_name)
@@ -41,10 +100,15 @@ pub(crate) fn contains(nc: &NameClass, target_name: QualifiedName) -> bool {
                 false
             }
         }
-        NameClass::AnyName { except } => match except {
-            None => true,
-            Some(nc) => !contains(nc, target_name),
-        },
+        NameClass::AnyName { except } => {
+            if !is_ncname(target_name.local_name) {
+                return false;
+            }
+            match except {
+                None => true,
+                Some(nc) => !contains(nc, target_name),
+            }
+        }
         NameClass::Alt { a, b } => contains(a, target_name) || contains(b, target_name),
     }
 }

--- a/relaxng-validator/src/schema.rs
+++ b/relaxng-validator/src/schema.rs
@@ -70,7 +70,35 @@ impl Pat {
 // Schema internals
 // ---------------------------------------------------------------------------
 
-pub(crate) type NameCache = HashMap<(PatId, Box<str>, Option<Box<str>>), PatId>;
+/// Interned namespace URI identifier. Comparing two `NsId` values is equivalent
+/// to comparing the URI strings they represent, but costs a single u32 comparison
+/// instead of hashing/comparing the full URI.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct NsId(u32);
+
+/// Interns namespace URI strings so that repeated lookups use a cheap integer key.
+#[derive(Default)]
+pub(crate) struct NamespaceInterner {
+    uris: Vec<String>,
+}
+
+impl NamespaceInterner {
+    pub(crate) fn intern(&mut self, uri: &str) -> NsId {
+        if let Some(pos) = self.uris.iter().position(|u| u == uri) {
+            NsId(pos as u32)
+        } else {
+            let id = NsId(self.uris.len() as u32);
+            self.uris.push(uri.to_owned());
+            id
+        }
+    }
+
+    pub(crate) fn intern_opt(&mut self, uri: Option<&str>) -> Option<NsId> {
+        uri.map(|u| self.intern(u))
+    }
+}
+
+pub(crate) type NameCache = HashMap<(PatId, Box<[u8]>, Option<NsId>), PatId>;
 
 #[derive(Default)]
 pub(crate) struct Inner {
@@ -119,6 +147,8 @@ pub(crate) struct Schema {
     pub(crate) ns_context: Option<NsContext>,
     /// When true, `ns_context` needs rebuilding before use.
     pub(crate) ns_context_dirty: bool,
+    /// Interner for namespace URI strings used in derivative cache keys.
+    pub(crate) ns_interner: NamespaceInterner,
 }
 
 impl Schema {
@@ -275,67 +305,6 @@ impl Schema {
     }
     pub(crate) fn patt(&self, id: PatId) -> Pat {
         self.inner.borrow().patterns[id.0 as usize].clone()
-    }
-
-    pub(crate) fn check_choice(
-        &self,
-        id: PatId,
-        seen: &mut Vec<PatId>,
-        seen_choices: &mut Vec<PatId>,
-    ) -> bool {
-        if seen_choices.contains(&id) {
-            println!(
-                "Choice contains duplicate pattern {:?} {:?}",
-                id,
-                self.patt(id)
-            );
-        }
-        seen.push(id);
-        match self.patt(id) {
-            Pat::Choice(l, r, _) => {
-                self.check_choice(l, seen, seen_choices);
-                self.check_choice(r, seen, seen_choices);
-            }
-            Pat::Interleave(l, r, _) | Pat::Group(l, r, _) => {
-                self.check_choices(l, seen);
-                self.check_choices(r, seen);
-            }
-            Pat::Empty => {}
-            Pat::Text => {}
-            Pat::NotAllowed => {}
-            Pat::OneOrMore(p, _) | Pat::Attribute(_, p) | Pat::Element(_, p) | Pat::List(p) => {
-                self.check_choices(p, seen)
-            }
-            Pat::Datatype(_) => {}
-            Pat::DatatypeValue(_) => {}
-            Pat::DatatypeExcept(_, _) => {}
-            Pat::After(_, _) => unreachable!(),
-        }
-        false
-    }
-
-    pub(crate) fn check_choices(&self, id: PatId, seen: &mut Vec<PatId>) {
-        if seen.contains(&id) {
-            return;
-        }
-        seen.push(id);
-        match self.patt(id) {
-            Pat::Choice(_, _, _) => {
-                let mut seen_choices = vec![];
-                self.check_choice(id, seen, &mut seen_choices);
-            }
-            Pat::Interleave(l, r, _) | Pat::Group(l, r, _) => {
-                self.check_choices(l, seen);
-                self.check_choices(r, seen);
-            }
-            Pat::OneOrMore(p, _) | Pat::Attribute(_, p) | Pat::Element(_, p) | Pat::List(p) => {
-                self.check_choices(p, seen)
-            }
-            Pat::Empty | Pat::Text | Pat::NotAllowed | Pat::Datatype(_) | Pat::DatatypeValue(_) => {
-            }
-            Pat::DatatypeExcept(_, p) => self.check_choices(p, seen),
-            Pat::After(_, _) => unreachable!(),
-        }
     }
 
     #[allow(unused)]
@@ -546,6 +515,9 @@ struct SchemaBuilder {
 
 impl SchemaBuilder {
     fn new() -> Self {
+        // `Pat` contains regex caches (atomics, mutexes) that the lint flags as
+        // interior-mutable. We never mutate keys after insertion, so this is safe.
+        #[allow(clippy::mutable_key_type)]
         let mut memo = HashMap::new();
         let patterns = vec![
             Some(Pat::NotAllowed), // PAT_NOT_ALLOWED = 0

--- a/relaxng-validator/tests/spectest.rs
+++ b/relaxng-validator/tests/spectest.rs
@@ -61,7 +61,7 @@ fn collect_suite<'a, 'input>(
             } else if child.tag_name() == ExpandedName::from("testCase") {
                 collect_case(trials, counters, path, &suite_name, child);
             } else if child.tag_name() == ExpandedName::from("documentation") {
-                suite_name = child.text().map(|t| slugify(t));
+                suite_name = child.text().map(slugify);
             }
         }
     }
@@ -129,12 +129,13 @@ fn is_suppressed(test_case: &TestCase) -> bool {
         let mut c = create_compiler(resources);
         c.compile(Path::new(&schema_key))
     });
-    match result {
-        Ok(Err(relaxng_model::RelaxError::XmlParse(_, relaxng_syntax::xml::Error::Todo(_)))) => {
-            true
-        }
-        _ => false,
-    }
+    matches!(
+        result,
+        Ok(Err(relaxng_model::RelaxError::XmlParse(
+            _,
+            relaxng_syntax::xml::Error::Todo(_)
+        )))
+    )
 }
 
 fn run_test(test_case: TestCase) -> Result<(), Failed> {
@@ -166,39 +167,20 @@ fn run_test(test_case: TestCase) -> Result<(), Failed> {
             };
 
             for (i, doc) in valid.iter().enumerate() {
-                let reader = xmlparser::Tokenizer::from(&doc[..]);
-                let mut v = Validator::new(result.start.clone(), reader).unwrap();
-                loop {
-                    match v.validate_next() {
-                        None => break,
-                        Some(Ok(())) => {}
-                        Some(Err(err)) => {
-                            let schema = resources.get("correct.rng").unwrap();
-                            return Err(format!(
-                                "Valid document #{} rejected: {err:?}\nschema: {schema}\ndoc: {doc}",
-                                i + 1
-                            )
-                            .into());
-                        }
-                    }
+                let mut v = Validator::new(result.start.clone()).unwrap();
+                if let Err(err) = v.validate(doc.as_bytes()) {
+                    let schema = resources.get("correct.rng").unwrap();
+                    return Err(format!(
+                        "Valid document #{} rejected: {err:?}\nschema: {schema}\ndoc: {doc}",
+                        i + 1
+                    )
+                    .into());
                 }
             }
 
             for (i, doc) in invalid.iter().enumerate() {
-                let reader = xmlparser::Tokenizer::from(&doc[..]);
-                let mut v = Validator::new(result.start.clone(), reader).unwrap();
-                let mut was_rejected = false;
-                loop {
-                    match v.validate_next() {
-                        None => break,
-                        Some(Ok(())) => {}
-                        Some(Err(_)) => {
-                            was_rejected = true;
-                            break;
-                        }
-                    }
-                }
-                if !was_rejected {
+                let mut v = Validator::new(result.start.clone()).unwrap();
+                if v.validate(doc.as_bytes()).is_ok() {
                     let schema = resources.get("correct.rng").unwrap();
                     return Err(format!(
                         "Invalid document #{} was accepted:\nschema: {schema}\ndoc: {doc}",
@@ -344,15 +326,15 @@ fn load_resources(path: &Path, resources: &mut HashMap<String, String>, node: No
 fn stringify(node: Node) -> String {
     let mut res = String::new();
     // extra work to give the first line consistent indentation with the rest of the lines
-    if let Some(prev) = node.prev_sibling() {
-        if let Some(text) = prev.text() {
-            let last_line = if let Some(pos) = text.rfind('\n') {
-                &text[pos + 1..]
-            } else {
-                text
-            };
-            res.push_str(last_line);
-        }
+    if let Some(prev) = node.prev_sibling()
+        && let Some(text) = prev.text()
+    {
+        let last_line = if let Some(pos) = text.rfind('\n') {
+            &text[pos + 1..]
+        } else {
+            text
+        };
+        res.push_str(last_line);
     }
     res.push_str(&node.document().input_text()[node.range()]);
     res


### PR DESCRIPTION
Switches from `xmlparser` to `xml-syntax-reader` in order to,

1. be able to parse documents larger than memory
2. apply a few other optimisations, like omitting some explicit utf8 checks where we can be sure by other means that input is utf8-valid