### PR TITLE
Three fixes found while validating OpenDocument files against the official OASIS schemas

### DIFF
--- a/relaxng-exemplifier/src/datatypes.rs
+++ b/relaxng-exemplifier/src/datatypes.rs
@@ -37,9 +37,10 @@ fn generate_relax_datatype(dt: &BuiltinDatatype, u: &mut Unstructured) -> String
 fn generate_xsd_datatype(dt: &XsdDatatypes, u: &mut Unstructured) -> String {
     use relaxng_model::datatype::xsd::*;
     match dt {
-        XsdDatatypes::String(_) | XsdDatatypes::NormalizedString(_) | XsdDatatypes::Token(_) => {
-            gen_short_ascii(u)
-        }
+        XsdDatatypes::String(_)
+        | XsdDatatypes::NormalizedString(_)
+        | XsdDatatypes::Token(_)
+        | XsdDatatypes::QName(_) => gen_short_ascii(u),
         XsdDatatypes::Boolean(_) => {
             if u.arbitrary::<bool>().unwrap_or(false) {
                 "true".to_string()

--- a/relaxng-model/src/datatype/xsd.rs
+++ b/relaxng-model/src/datatype/xsd.rs
@@ -120,6 +120,7 @@ pub enum XsdDatatypes {
     NmTokens(LengthFacet, Option<PatternFacet>),
     NmToken(StringFacets),
     NcName(StringFacets),
+    QName(StringFacets),
     Name(StringFacets),
     Token(StringFacets),
     Duration(Option<PatternFacet>),
@@ -262,6 +263,7 @@ impl super::Datatype for XsdDatatypes {
             XsdDatatypes::NcName(str_facets) => {
                 is_valid_ncname(value) && str_facets.is_valid(value)
             }
+            XsdDatatypes::QName(str_facets) => is_valid_qname(value) && str_facets.is_valid(value),
             XsdDatatypes::Name(str_facets) => is_valid_name(value) && str_facets.is_valid(value),
             XsdDatatypes::Token(str_facets) => {
                 let normalized = super::relax::normalize_whitespace(value);
@@ -417,6 +419,16 @@ fn is_valid_ncname(text: &str) -> bool {
     match relaxng_syntax::compact::nc_name(relaxng_syntax::compact::Span::new(text)) {
         Ok((rest, _name)) => rest.fragment().is_empty(),
         Err(_) => false,
+    }
+}
+
+/// Lexical check only; resolution of the prefix against in-scope namespace bindings of the
+/// instance document is not performed.
+fn is_valid_qname(text: &str) -> bool {
+    let text = text.trim_matches(['\x20', '\x09', '\x0a', '\x0d']);
+    match text.split_once(':') {
+        Some((prefix, local)) => is_valid_ncname(prefix) && is_valid_ncname(local),
+        None => is_valid_ncname(text),
     }
 }
 
@@ -980,6 +992,12 @@ impl Compiler {
                     type_name: "NCName",
                     facet,
                 }),
+            "QName" => self
+                .qname(ctx, params)
+                .map_err(|facet| XsdDatatypeError::Facet {
+                    type_name: "QName",
+                    facet,
+                }),
             "Name" => self
                 .name(ctx, params)
                 .map_err(|facet| XsdDatatypeError::Facet {
@@ -1492,6 +1510,28 @@ impl Compiler {
         }
 
         Ok(XsdDatatypes::NcName(StringFacets { len, pattern }))
+    }
+
+    fn qname(&self, ctx: &Context, params: &[types::Param]) -> Result<XsdDatatypes, FacetError> {
+        let mut len = LengthFacet::Unbounded;
+        let mut pattern = None;
+
+        for param in params {
+            match &param.name.to_string()[..] {
+                "length" => len.merge(LengthFacet::Length(Self::usize(ctx, param)?))?,
+                "minLength" => len.merge(LengthFacet::MinLength(Self::usize(ctx, param)?))?,
+                "maxLength" => len.merge(LengthFacet::MaxLength(Self::usize(ctx, param)?))?,
+                "pattern" => pattern = Some(self.pattern(ctx, param)?),
+                _ => {
+                    return Err(FacetError::InvalidFacet(
+                        ctx.convert_span(&param.span),
+                        param.name.to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(XsdDatatypes::QName(StringFacets { len, pattern }))
     }
 
     fn token(&self, ctx: &Context, params: &[types::Param]) -> Result<XsdDatatypes, FacetError> {
@@ -2394,6 +2434,29 @@ mod test {
         c.compile(&ctx, &(0..0), name, &[]).unwrap()
     }
 
+    // Helper: compile an XSD datatype with a single param
+    fn compile_one_param(name: &str, param_name: &str, param_value: &str) -> XsdDatatypes {
+        let mut map = CodeMap::new();
+        let file = map.add_file("test.rnc".to_string(), "test".to_string());
+        let ctx = Context::new(file);
+        let c = Compiler;
+        let param = types::Param {
+            span: 0..0,
+            annotations: None,
+            name: types::IdentifierOrKeyword::Identifier(types::Identifier(
+                0..0,
+                param_name.to_string(),
+            )),
+            value: types::Literal(
+                0..0,
+                vec![types::LiteralSegment {
+                    body: param_value.to_string(),
+                }],
+            ),
+        };
+        c.compile(&ctx, &(0..0), name, &[param]).unwrap()
+    }
+
     use crate::datatype::Datatype;
 
     #[test]
@@ -2616,6 +2679,26 @@ mod test {
         assert!(dt.is_valid("_underscore"));
         assert!(!dt.is_valid("123"));
         assert!(!dt.is_valid(""));
+    }
+
+    #[test]
+    fn qname_valid() {
+        let dt = compile_no_params("QName");
+        assert!(dt.is_valid("foo"));
+        assert!(dt.is_valid("style:font-face"));
+        assert!(dt.is_valid(" eg:foo ")); // surrounding whitespace is collapsed
+        assert!(!dt.is_valid("a:b:c")); // at most one colon
+        assert!(!dt.is_valid(":foo")); // empty prefix
+        assert!(!dt.is_valid("eg:")); // empty local part
+        assert!(!dt.is_valid("1a:foo")); // prefix must be an NCName
+        assert!(!dt.is_valid(""));
+    }
+
+    #[test]
+    fn qname_pattern_facet() {
+        let dt = compile_one_param("QName", "pattern", "[a-z]+:[a-z\\-]+");
+        assert!(dt.is_valid("style:font-face"));
+        assert!(!dt.is_valid("font-face")); // pattern requires a prefix
     }
 
     #[test]

--- a/relaxng-syntax/src/xml.rs
+++ b/relaxng-syntax/src/xml.rs
@@ -529,8 +529,9 @@ fn data(node: Node) -> Result<DatatypeNamePattern> {
         .attribute_node("type")
         .ok_or(Error::Expected(node.range(), "type attribute"))?;
     let type_name = match type_attr.value().trim() {
-        // TODO: check datatypeLibrary namespace!
-        "token" => DatatypeName::Token,
+        // The bare 'token' shortcut only applies to the relaxng built-in datatype library;
+        // with an inherited datatypeLibrary (e.g. XML Schema), 'token' is that library's type.
+        "token" if datatype_ns.as_string_value().is_empty() => DatatypeName::Token,
         val => {
             let name = ncname(type_attr.range_value(), val)?;
             DatatypeName::NamespacedName(NamespacedName {
@@ -1226,6 +1227,41 @@ mod tests {
                 el.name_class,
                 NameClass::Name(Name::NamespacedName(NamespacedName { namespace_uri: ns, localname: NcName(_, name)}))
                     if ns.as_string_value() == "http://example.com/ns" && name == "foo"
+            )
+        } else {
+            panic!("Expected an <element>")
+        }
+    }
+
+    #[test]
+    fn data_token_with_inherited_datatype_library_is_namespaced() {
+        let doc = roxmltree::Document::parse(
+            "<element xmlns=\"http://relaxng.org/ns/structure/1.0\" name=\"foo\" datatypeLibrary=\"http://www.w3.org/2001/XMLSchema-datatypes\"><data type=\"token\"/></element>",
+        )
+        .expect("Parsing XML");
+        let result = super::pattern(doc.root_element()).unwrap();
+        if let Pattern::Element(el) = result {
+            assert_matches!(
+                *el.pattern,
+                Pattern::DatatypeName(DatatypeNamePattern(_, DatatypeName::NamespacedName(NamespacedName { namespace_uri: ref ns, localname: NcName(_, ref name) }), _, _))
+                    if ns.as_string_value() == "http://www.w3.org/2001/XMLSchema-datatypes" && name == "token"
+            )
+        } else {
+            panic!("Expected an <element>")
+        }
+    }
+
+    #[test]
+    fn data_token_without_datatype_library_is_builtin() {
+        let doc = roxmltree::Document::parse(
+            "<element xmlns=\"http://relaxng.org/ns/structure/1.0\" name=\"foo\"><data type=\"token\"/></element>",
+        )
+        .expect("Parsing XML");
+        let result = super::pattern(doc.root_element()).unwrap();
+        if let Pattern::Element(el) = result {
+            assert_matches!(
+                *el.pattern,
+                Pattern::DatatypeName(DatatypeNamePattern(_, DatatypeName::Token, _, _))
             )
         } else {
             panic!("Expected an <element>")

--- a/relaxng-syntax/src/xml.rs
+++ b/relaxng-syntax/src/xml.rs
@@ -914,6 +914,15 @@ fn qname_el(name: Node) -> Result<Name> {
         if let Some(pos) = val.find(':') {
             let start = name.range().start;
             let end = name.range().end;
+            // Resolve the prefix against in-scope xmlns declarations, as qname_att() does for
+            // name attributes; fall back to a CName for the model to resolve from declarations.
+            if let Some(namespace) = lookup_namespace_def(name, Some(val[0..pos].trim())) {
+                let localname = ncname(start + pos + 1..end, val[pos + 1..].trim())?;
+                return Ok(Name::NamespacedName(NamespacedName {
+                    namespace_uri: Literal::new(start..(start + pos), namespace.to_string()),
+                    localname,
+                }));
+            }
             let prefix = ncname(start..(start + pos), val[0..pos].trim())?;
             let localname = ncname(start + pos + 1..end, val[pos + 1..].trim())?;
             Ok(Name::CName(QName(prefix, localname)))
@@ -1199,6 +1208,42 @@ mod tests {
             assert_matches!(
                 el.name_class,
                 NameClass::Name(Name::NamespacedName(NamespacedName { namespace_uri: _, localname: NcName(_, name)})) if name == "library"
+            )
+        } else {
+            panic!("Expected an <element>")
+        }
+    }
+
+    #[test]
+    fn prefixed_name_element_resolves_against_xmlns() {
+        let doc = roxmltree::Document::parse(
+            "<element xmlns=\"http://relaxng.org/ns/structure/1.0\" xmlns:eg=\"http://example.com/ns\"><name>eg:foo</name><text/></element>",
+        )
+        .expect("Parsing XML");
+        let result = super::pattern(doc.root_element()).unwrap();
+        if let Pattern::Element(el) = result {
+            assert_matches!(
+                el.name_class,
+                NameClass::Name(Name::NamespacedName(NamespacedName { namespace_uri: ns, localname: NcName(_, name)}))
+                    if ns.as_string_value() == "http://example.com/ns" && name == "foo"
+            )
+        } else {
+            panic!("Expected an <element>")
+        }
+    }
+
+    #[test]
+    fn prefixed_name_element_with_undeclared_prefix_falls_back_to_cname() {
+        let doc = roxmltree::Document::parse(
+            "<element xmlns=\"http://relaxng.org/ns/structure/1.0\"><name>eg:foo</name><text/></element>",
+        )
+        .expect("Parsing XML");
+        let result = super::pattern(doc.root_element()).unwrap();
+        if let Pattern::Element(el) = result {
+            assert_matches!(
+                el.name_class,
+                NameClass::Name(Name::CName(QName(NcName(_, prefix), NcName(_, name))))
+                    if prefix == "eg" && name == "foo"
             )
         } else {
             panic!("Expected an <element>")

--- a/relaxng-validator/src/nameclass.rs
+++ b/relaxng-validator/src/nameclass.rs
@@ -119,6 +119,7 @@ pub(crate) fn describe_datatype(dt: &datatype::Datatypes) -> String {
                 NmTokens(..) => "xsd:NMTOKENS",
                 NmToken(_) => "xsd:NMTOKEN",
                 NcName(_) => "xsd:NCName",
+                QName(_) => "xsd:QName",
                 Name(_) => "xsd:Name",
                 Duration(_) => "xsd:duration",
                 Date(_) => "xsd:date",

--- a/relaxng-validator/tests/spectest.xml
+++ b/relaxng-validator/tests/spectest.xml
@@ -6841,6 +6841,20 @@ before string sequence checking.</documentation>
 <foo/>
 </invalid>
 </testCase>
+<testCase>
+<correct>
+<element xmlns="http://relaxng.org/ns/structure/1.0" xmlns:eg="http://example.com/ns">
+  <name>eg:foo</name>
+  <text/>
+</element>
+</correct>
+<valid>
+<eg:foo xmlns:eg="http://example.com/ns">hello</eg:foo>
+</valid>
+<invalid>
+<foo>hello</foo>
+</invalid>
+</testCase>
 </testSuite>
 <testSuite>
 <documentation>Validation error reporting</documentation>

--- a/relaxng-validator/tests/spectest.xml
+++ b/relaxng-validator/tests/spectest.xml
@@ -6855,6 +6855,21 @@ before string sequence checking.</documentation>
 <foo>hello</foo>
 </invalid>
 </testCase>
+<testCase>
+<correct>
+<element xmlns="http://relaxng.org/ns/structure/1.0" name="foo" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="token">
+    <param name="pattern">[a-z]+</param>
+  </data>
+</element>
+</correct>
+<valid>
+<foo>abc</foo>
+</valid>
+<invalid>
+<foo>ABC</foo>
+</invalid>
+</testCase>
 </testSuite>
 <testSuite>
 <documentation>Validation error reporting</documentation>

--- a/relaxng-validator/tests/spectest.xml
+++ b/relaxng-validator/tests/spectest.xml
@@ -6870,6 +6870,25 @@ before string sequence checking.</documentation>
 <foo>ABC</foo>
 </invalid>
 </testCase>
+<testCase>
+<correct>
+<element xmlns="http://relaxng.org/ns/structure/1.0" name="foo" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="QName"/>
+</element>
+</correct>
+<valid>
+<foo xmlns:eg="http://example.com/ns">eg:bar</foo>
+</valid>
+<valid>
+<foo>bar</foo>
+</valid>
+<invalid>
+<foo>eg:bar:baz</foo>
+</invalid>
+<invalid>
+<foo>:bar</foo>
+</invalid>
+</testCase>
 </testSuite>
 <testSuite>
 <documentation>Validation error reporting</documentation>


### PR DESCRIPTION
I tried to validate ODF (OpenDocument) files against the official OASIS
RELAX NG schemas (XML syntax, ~18k lines, XSD datatype library) and hit
three independent issues that prevented the schemas from loading. With
the three commits in this PR, the OpenDocument v1.2/1.3/1.4 main
schemas, the manifest schema, and the multi-file MathML3 schema all
load, and validation verdicts agree with `jing -i` on every document I
tested (valid documents and deliberately-broken ones).

Each commit is self-contained, with unit tests and a regression case in
the `Regressions` section of `spectest.xml` (each regression case fails
without the corresponding fix).

## 1. QName prefix resolution in XML-syntax `<name>` elements

`qname_att()` resolves the prefix of a `name="pfx:local"` attribute
against the in-scope `xmlns` declarations, but `qname_el()` returned an
unresolved `CName` for `<name>pfx:local</name>` child elements. The
`CName` was then handed to relaxng-model's `Context`, whose namespace
table is only populated by compact-syntax `namespace` declarations, so
every prefixed `<name>` in an XML-syntax schema failed with
`Undefined namespace prefix`. The fix resolves the prefix the same way
`qname_att()` does, falling back to a `CName` when the prefix is not
declared.

## 2. `<data type="token">` ignored the inherited datatypeLibrary

`data()` unconditionally mapped `type="token"` to the relaxng built-in
token datatype (which accepts no parameters) — the existing
`// TODO: check datatypeLibrary namespace!` comment acknowledged this.
With `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
inherited from the `grammar` root, `token` must map to `xsd:token`,
which supports facet params; the ODF schemas use
`<data type="token"><param name="pattern">…` for e.g. language/country
codes, and failed with "remove this parameter". The fix only takes the
built-in shortcut when no datatypeLibrary is in scope.

## 3. `<data type="QName"/>` was not supported

QName worked in `<value>` patterns, but `<data type="QName">` failed to
compile with `Unsupported datatype "QName"` (the README lists QName as
supported). Implemented as a lexical check — `NCName(':' NCName)?` —
with the same length/pattern facets as NCName.

**Known limitation (intentional, called out rather than hidden):** the
prefix is not resolved against the in-scope namespace bindings of the
instance document, so a lexically valid QName with an undeclared prefix
is accepted. Doing that properly needs the instance's namespace context
plumbed into datatype validation; happy to discuss whether/how you'd
want that done, possibly sharing the machinery the `<value>` QName
support already has.

## Testing

- `cargo test --workspace`: 577 → 583 tests, all passing (6 new unit
  tests, 3 new spectest regression cases).
- `cargo fmt --all -- --check` clean.
- End-to-end: OASIS OpenDocument v1.2/1.3/1.4 + manifest + MathML3
  schemas load; verdicts on real and deliberately-invalid ODF content
  match `jing -i` exactly. (For context: jing itself needs `-i` because
  the official ODF schema violates RELAX NG DTD-compatibility ID rules
  — these schemas are a demanding real-world test case, and this crate
  handles them well.)